### PR TITLE
✨ Feat(#12): Input 공통 컴포넌트 제작

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -17,10 +17,16 @@ input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 input:-webkit-autofill:active {
-  transition: background-color 5000s ease-in-out 0s;
-  -webkit-transition: background-color 9999s ease-out;
+  -webkit-transition:
+    background-color 5000s ease-in-out 0s,
+    color 5000s ease-in-out 0s;
+  transition:
+    background-color 5000s ease-in-out 0s,
+    color 5000s ease-in-out 0s;
   -webkit-box-shadow: 0 0 0px 1000px #1e293b inset !important;
+  box-shadow: 0 0 0px 1000px #1e293b inset !important;
   -webkit-text-fill-color: #f8fafc !important;
+  caret-color: #f8fafc !important;
 }
 
 input {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,3 +12,17 @@
   font-family: "Pretendard-Regular", Arial, sans-serif;
   box-sizing: border-box;
 }
+
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  transition: background-color 5000s ease-in-out 0s;
+  -webkit-transition: background-color 9999s ease-out;
+  -webkit-box-shadow: 0 0 0px 1000px #1e293b inset !important;
+  -webkit-text-fill-color: #f8fafc !important;
+}
+
+input {
+  caret-color: #f8fafc;
+}

--- a/src/components/common/Form/ErrorMessage/index.stories.tsx
+++ b/src/components/common/Form/ErrorMessage/index.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useRef } from "react";
+
+import Input from "../Input";
+import ErrorMessage from ".";
+
+const meta = {
+  title: "Components/Form/ErrorMessage",
+  component: ErrorMessage,
+  tags: ["autodocs"],
+} as Meta<typeof ErrorMessage>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    message: "알맞은 형식을 입력하세요.",
+  },
+};
+
+export const TextareaWrapper: Story = {
+  render: () => (
+    <div className="flex flex-col gap-8">
+      <Input
+        id="email"
+        isError
+        type="email"
+        placeholder="내용을 입력해주세요"
+      />
+      <ErrorMessage message="모달창에 있는 인풋은 label이 없는 것도 있음" />
+    </div>
+  ),
+};

--- a/src/components/common/Form/ErrorMessage/index.tsx
+++ b/src/components/common/Form/ErrorMessage/index.tsx
@@ -1,0 +1,10 @@
+interface ErrorMessageProps {
+  /** 에러메시지 입니다. */
+  message: string;
+}
+
+const ErrorMessage = ({ message }: ErrorMessageProps) => (
+  <span className="text-status-danger">{message}</span>
+);
+
+export default ErrorMessage;

--- a/src/components/common/Form/ErrorMessage/index.tsx
+++ b/src/components/common/Form/ErrorMessage/index.tsx
@@ -4,7 +4,7 @@ interface ErrorMessageProps {
 }
 
 const ErrorMessage = ({ message }: ErrorMessageProps) => (
-  <span className="text-status-danger">{message}</span>
+  <span className="text-md-medium text-status-danger">{message}</span>
 );
 
 export default ErrorMessage;

--- a/src/components/common/Form/FieldWrapper/index.stories.tsx
+++ b/src/components/common/Form/FieldWrapper/index.stories.tsx
@@ -1,0 +1,53 @@
+/* eslint-disable no-console */
+/* eslint-disable react-hooks/rules-of-hooks */
+import type { Meta, StoryObj } from "@storybook/react";
+import { useEffect, useRef } from "react";
+
+import Input from "../Input";
+import FieldWrapper from ".";
+
+const meta = {
+  title: "Components/Form/FieldWrapper",
+  component: FieldWrapper,
+  tags: ["autodocs"],
+} as Meta<typeof FieldWrapper>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    id: "email",
+    label: "이메일",
+    errorMessage: "알맞은 형식을 입력하세요.",
+  },
+};
+
+export const InputWrapper: Story = {
+  render: () => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+      if (inputRef.current) {
+        console.log(inputRef.current);
+      }
+    }, []);
+
+    return (
+      <FieldWrapper
+        id="password"
+        label="비밀번호"
+        errorMessage="비밀번호는 8자 이상입니다"
+      >
+        <Input
+          ref={inputRef}
+          id="password"
+          type="password"
+          placeholder="비밀번호를 입력해주세요"
+          isError
+        />
+      </FieldWrapper>
+    );
+  },
+};

--- a/src/components/common/Form/FieldWrapper/index.stories.tsx
+++ b/src/components/common/Form/FieldWrapper/index.stories.tsx
@@ -4,6 +4,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useEffect, useRef } from "react";
 
 import Input from "../Input";
+import Textarea from "../Textarea";
 import FieldWrapper from ".";
 
 const meta = {
@@ -50,4 +51,26 @@ export const InputWrapper: Story = {
       </FieldWrapper>
     );
   },
+};
+
+export const TextareaWrapper: Story = {
+  render: () => (
+    <FieldWrapper
+      id="content"
+      label={
+        <span>
+          <span className="text-brand-primary">* </span>
+          내용
+        </span>
+      }
+    >
+      <Textarea
+        id="content"
+        placeholder="내용을 입력해주세요"
+        maxLength={20}
+        rows={5}
+        isError={false}
+      />
+    </FieldWrapper>
+  ),
 };

--- a/src/components/common/Form/FieldWrapper/index.tsx
+++ b/src/components/common/Form/FieldWrapper/index.tsx
@@ -1,0 +1,29 @@
+import { ReactNode } from "react";
+
+interface FieldWrapperProps {
+  /** input의 id 와 연결되는 label 의 htmlFor 값 입니다. */
+  id: string;
+  /** label입니다 */
+  label: ReactNode;
+  /** FormWrapper 안에 들어갈 input 입니다. */
+  children: ReactNode;
+  /** 에러메시지입니다. */
+  errorMessage?: string;
+}
+
+const FieldWrapper = ({
+  id,
+  label,
+  children,
+  errorMessage = "",
+}: FieldWrapperProps) => (
+  <section className="flex flex-col gap-8">
+    <label htmlFor={id} className="mb-4 text-text-primary">
+      {label}
+    </label>
+    {children}
+    {errorMessage && <span className="text-status-danger">{errorMessage}</span>}
+  </section>
+);
+
+export default FieldWrapper;

--- a/src/components/common/Form/FieldWrapper/index.tsx
+++ b/src/components/common/Form/FieldWrapper/index.tsx
@@ -20,7 +20,7 @@ const FieldWrapper = ({
   errorMessage = "",
 }: FieldWrapperProps) => (
   <section className="flex flex-col gap-8">
-    <label htmlFor={id} className="mb-4 text-text-primary">
+    <label htmlFor={id} className="mb-4 text-lg-medium text-text-primary">
       {label}
     </label>
     {children}

--- a/src/components/common/Form/FieldWrapper/index.tsx
+++ b/src/components/common/Form/FieldWrapper/index.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from "react";
 
+import ErrorMessage from "../ErrorMessage";
+
 interface FieldWrapperProps {
   /** input의 id 와 연결되는 label 의 htmlFor 값 입니다. */
   id: string;
@@ -22,7 +24,7 @@ const FieldWrapper = ({
       {label}
     </label>
     {children}
-    {errorMessage && <span className="text-status-danger">{errorMessage}</span>}
+    {errorMessage && <ErrorMessage message={errorMessage} />}
   </section>
 );
 

--- a/src/components/common/Form/Input/index.stories.tsx
+++ b/src/components/common/Form/Input/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
 
 import Input from ".";
 
@@ -9,6 +10,28 @@ const meta = {
   args: {
     isError: false,
     isDisabled: false,
+    type: "text",
+  },
+  argTypes: {
+    isError: {
+      control: "boolean",
+      description: "input의 error 여부입니다.",
+    },
+    isDisabled: {
+      control: "boolean",
+      description: "input의 disabled 여부입니다.",
+    },
+    type: {
+      control: "radio",
+      options: ["text", "email", "password"],
+      description: "input 의 타입입니다.",
+    },
+    id: {
+      description: "input의 id 속성입니다. name 속성도 동일하게 적용됩니다.",
+    },
+    placeholder: {
+      description: "input의 placeholder 속성입니다.",
+    },
   },
 } as Meta<typeof Input>;
 
@@ -18,7 +41,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Primary: Story = {
   args: {
-    id: "name",
-    placeholder: "이름을 입력하세요",
+    id: "content",
+    placeholder: "비밀번호를 입력하세요",
+    type: "password",
   },
 };

--- a/src/components/common/Form/Input/index.stories.tsx
+++ b/src/components/common/Form/Input/index.stories.tsx
@@ -39,9 +39,17 @@ export default meta;
 
 type Story = StoryObj<typeof meta>;
 
-export const Primary: Story = {
+export const Email: Story = {
   args: {
-    id: "content",
+    id: "email",
+    placeholder: "이메일을 입력하세요",
+    type: "email",
+  },
+};
+
+export const Password: Story = {
+  args: {
+    id: "password",
     placeholder: "비밀번호를 입력하세요",
     type: "password",
   },

--- a/src/components/common/Form/Input/index.stories.tsx
+++ b/src/components/common/Form/Input/index.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Input from ".";
+
+const meta = {
+  title: "Components/Form/Input",
+  component: Input,
+  tags: ["autodocs"],
+  args: {
+    isError: false,
+    isDisabled: false,
+  },
+} as Meta<typeof Input>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    id: "name",
+    placeholder: "이름을 입력하세요",
+  },
+};

--- a/src/components/common/Form/Input/index.tsx
+++ b/src/components/common/Form/Input/index.tsx
@@ -1,5 +1,9 @@
+/* eslint-disable jsx-a11y/click-events-have-key-events */
 import { clsx } from "clsx";
-import React, { ComponentProps, forwardRef } from "react";
+import { ComponentProps, forwardRef, useState } from "react";
+
+import useBoolean from "@/hooks/useToggle";
+import { IconVisibilityOff, IconVisibilityOn } from "@/public/assets/icons";
 
 interface InputProps extends ComponentProps<"input"> {
   /** input의 id 속성입니다. name 속성도 동일하게 적용됩니다. */
@@ -10,28 +14,64 @@ interface InputProps extends ComponentProps<"input"> {
   isError?: boolean;
   /** input의 disabled 여부입니다. */
   isDisabled?: boolean;
+  /** input 의 타입입니다. text, email, password */
+  type?: "text" | "email" | "password";
 }
 
 const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ id, placeholder, isError = false, isDisabled = false, ...props }, ref) => (
-    <input
-      className={clsx(
-        "w-full rounded-xl px-16 py-15 text-text-primary outline-none ring-1",
-        isError
-          ? "ring-status-danger"
-          : "ring-border-primary focus:ring-brand-primary",
-        isDisabled
-          ? "cursor-not-allowed bg-background-tertiary opacity-70"
-          : "bg-background-secondary",
-      )}
-      id={id}
-      name={id}
-      placeholder={placeholder}
-      ref={ref}
-      disabled={isDisabled}
-      {...props}
-    />
-  ),
+  (
+    {
+      id,
+      placeholder,
+      isError = false,
+      isDisabled = false,
+      type = "text",
+      ...props
+    },
+    ref,
+  ) => {
+    const [inputType, setInputType] = useState(type);
+    const { value: isVisible, handleToggle } = useBoolean();
+
+    const handleClickVisible = () => {
+      handleToggle();
+      setInputType(isVisible ? "password" : "text");
+    };
+
+    return (
+      <div className="relative">
+        <input
+          className={clsx(
+            "w-full rounded-xl px-16 py-15 text-text-primary outline-none ring-1",
+            isError
+              ? "ring-status-danger"
+              : "ring-border-primary focus:ring-brand-primary",
+            isDisabled
+              ? "cursor-not-allowed bg-background-tertiary opacity-70"
+              : "bg-background-secondary",
+          )}
+          id={id}
+          name={id}
+          placeholder={placeholder}
+          ref={ref}
+          disabled={isDisabled}
+          type={inputType}
+          {...props}
+        />
+        {type === "password" && (
+          <div
+            className="absolute right-16 top-15 cursor-pointer"
+            onClick={handleClickVisible}
+            role="button"
+            aria-label="Toggle password visibility"
+            tabIndex={0}
+          >
+            {isVisible ? <IconVisibilityOn /> : <IconVisibilityOff />}
+          </div>
+        )}
+      </div>
+    );
+  },
 );
 
 Input.displayName = "Input";

--- a/src/components/common/Form/Input/index.tsx
+++ b/src/components/common/Form/Input/index.tsx
@@ -35,17 +35,19 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
 
     const handleClickVisible = () => {
       handleToggle();
-      setInputType(isVisible ? "password" : "text");
+      setInputType((prevType) =>
+        prevType === "password" ? "text" : "password",
+      );
     };
 
     return (
       <div className="relative">
         <input
           className={clsx(
-            "w-full rounded-xl px-16 py-15 text-text-primary outline-none ring-1",
+            "w-full rounded-xl px-16 py-15 text-lg-regular text-text-primary outline-none ring-1 transition-all duration-300",
             isError
-              ? "ring-status-danger"
-              : "ring-border-primary focus:ring-brand-primary",
+              ? "ring-0.5 ring-offset-0.5 ring-status-danger ring-offset-status-danger"
+              : "focus:ring-0.5 focus:ring-offset-0.5 ring-border-primary focus:shadow-lg focus:outline-none focus:ring-brand-primary focus:ring-offset-brand-primary/10",
             isDisabled
               ? "cursor-not-allowed bg-background-tertiary opacity-70"
               : "bg-background-secondary",

--- a/src/components/common/Form/Input/index.tsx
+++ b/src/components/common/Form/Input/index.tsx
@@ -1,0 +1,39 @@
+import { clsx } from "clsx";
+import React, { ComponentProps, forwardRef } from "react";
+
+interface InputProps extends ComponentProps<"input"> {
+  /** input의 id 속성입니다. name 속성도 동일하게 적용됩니다. */
+  id: string;
+  /** input의 placeholder 속성입니다. */
+  placeholder: string;
+  /** input의 error 여부입니다. */
+  isError?: boolean;
+  /** input의 disabled 여부입니다. */
+  isDisabled?: boolean;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ id, placeholder, isError = false, isDisabled = false, ...props }, ref) => (
+    <input
+      className={clsx(
+        "w-full rounded-xl px-16 py-15 text-text-primary outline-none ring-1",
+        isError
+          ? "ring-status-danger"
+          : "ring-border-primary focus:ring-brand-primary",
+        isDisabled
+          ? "cursor-not-allowed bg-background-tertiary opacity-70"
+          : "bg-background-secondary",
+      )}
+      id={id}
+      name={id}
+      placeholder={placeholder}
+      ref={ref}
+      disabled={isDisabled}
+      {...props}
+    />
+  ),
+);
+
+Input.displayName = "Input";
+
+export default Input;

--- a/src/components/common/Form/Textarea/index.stories.tsx
+++ b/src/components/common/Form/Textarea/index.stories.tsx
@@ -10,6 +10,21 @@ const meta = {
     isError: false,
     rows: 3,
   },
+  argTypes: {
+    isError: {
+      control: "boolean",
+      description: "textarea 의 error 여부입니다.",
+    },
+    id: {
+      description: "textarea id 속성입니다. name 속성도 동일하게 적용됩니다.",
+    },
+    placeholder: {
+      description: "textarea placeholder 속성입니다.",
+    },
+    rows: {
+      description: "textarea 의 줄 수입니다.",
+    },
+  },
 } as Meta<typeof Textarea>;
 
 export default meta;

--- a/src/components/common/Form/Textarea/index.stories.tsx
+++ b/src/components/common/Form/Textarea/index.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import Textarea from ".";
+
+const meta = {
+  title: "Components/Form/Textarea",
+  component: Textarea,
+  tags: ["autodocs"],
+  args: {
+    isError: false,
+    rows: 3,
+  },
+} as Meta<typeof Textarea>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Primary: Story = {
+  args: {
+    id: "content",
+    placeholder: "내용을 입력하세요",
+  },
+};

--- a/src/components/common/Form/Textarea/index.tsx
+++ b/src/components/common/Form/Textarea/index.tsx
@@ -1,0 +1,36 @@
+import clsx from "clsx";
+import React, { ComponentProps, forwardRef } from "react";
+
+interface TextareaProps extends ComponentProps<"textarea"> {
+  /** input의 id 속성입니다. name 속성도 동일하게 적용됩니다. */
+  id: string;
+  /** input의 placeholder 속성입니다. */
+  placeholder: string;
+  /** input의 error 여부입니다. */
+  isError?: boolean;
+  /** textarea 의 줄 수입니다. */
+  rows?: number;
+}
+
+const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ id, placeholder, isError = false, rows = 2, ...props }, ref) => (
+    <textarea
+      className={clsx(
+        "w-full rounded-xl bg-background-secondary px-16 py-15 text-text-primary outline-none ring-1",
+        isError
+          ? "ring-status-danger"
+          : "ring-border-primary focus:ring-brand-primary",
+      )}
+      id={id}
+      name={id}
+      placeholder={placeholder}
+      rows={rows}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+
+Textarea.displayName = "Textarea";
+
+export default Textarea;

--- a/src/components/common/Form/Textarea/index.tsx
+++ b/src/components/common/Form/Textarea/index.tsx
@@ -16,7 +16,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ id, placeholder, isError = false, rows = 3, ...props }, ref) => (
     <textarea
       className={clsx(
-        "w-full rounded-xl bg-background-secondary px-16 py-15 text-text-primary outline-none ring-1",
+        "w-full resize-none rounded-xl bg-background-secondary px-16 py-15 text-text-primary outline-none ring-1",
         isError
           ? "ring-status-danger"
           : "ring-border-primary focus:ring-brand-primary",

--- a/src/components/common/Form/Textarea/index.tsx
+++ b/src/components/common/Form/Textarea/index.tsx
@@ -2,18 +2,18 @@ import clsx from "clsx";
 import React, { ComponentProps, forwardRef } from "react";
 
 interface TextareaProps extends ComponentProps<"textarea"> {
-  /** input의 id 속성입니다. name 속성도 동일하게 적용됩니다. */
+  /** textarea id 속성입니다. name 속성도 동일하게 적용됩니다. */
   id: string;
-  /** input의 placeholder 속성입니다. */
+  /** textarea placeholder 속성입니다. */
   placeholder: string;
-  /** input의 error 여부입니다. */
+  /** textarea error 여부입니다. */
   isError?: boolean;
   /** textarea 의 줄 수입니다. */
   rows?: number;
 }
 
 const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
-  ({ id, placeholder, isError = false, rows = 2, ...props }, ref) => (
+  ({ id, placeholder, isError = false, rows = 3, ...props }, ref) => (
     <textarea
       className={clsx(
         "w-full rounded-xl bg-background-secondary px-16 py-15 text-text-primary outline-none ring-1",

--- a/src/components/common/Form/Textarea/index.tsx
+++ b/src/components/common/Form/Textarea/index.tsx
@@ -16,7 +16,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ id, placeholder, isError = false, rows = 3, ...props }, ref) => (
     <textarea
       className={clsx(
-        "w-full resize-none rounded-xl bg-background-secondary px-16 py-15 text-text-primary outline-none ring-1",
+        "w-full resize-none rounded-xl bg-background-secondary px-16 py-15 text-lg-regular text-text-primary outline-none ring-1",
         isError
           ? "ring-status-danger"
           : "ring-border-primary focus:ring-brand-primary",

--- a/src/hooks/useToggle.ts
+++ b/src/hooks/useToggle.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from "react";
+
+const useBoolean = () => {
+  const [value, setValue] = useState(false);
+
+  const handleOn = useCallback(() => {
+    setValue(true);
+  }, []);
+
+  const handleOff = useCallback(() => {
+    setValue(false);
+  }, []);
+
+  const handleToggle = useCallback(() => {
+    setValue((prev) => !prev);
+  }, []);
+
+  return { value, handleOn, handleOff, handleToggle };
+};
+
+export default useBoolean;


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #12  <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

Input 공통 컴포넌트 제작했습니다. 다른 컴포넌트에서도 범용적으로 사용할 수 있게 만들어야 하니깐 어렵네요..
사용방법은 스토리북 위주로 보시면 될 거 같아요

### 1. Input

스토리북상에서는 password -> email or text 로 **type** 을 바꿨을 땐 약간 오류가 있는데 실제로는 정적인 type 만 사용해서 괜찮을 거 같아요.

그리고 `forwardRef` 를 사용하여 input 이 ref 를 받을 수 있게하였습니다. 왜냐하면 **react hook form** 의 **register** 가 **ref** 로 동작하는 거라 **Input** 컴포넌트에 **react hook form** 을 사용하려면 필요해서 사용하였습니다.
근데 단점으로는 `forwardRef` 가 있어서 스토리북의 args 가 자동으로 채워지지 않아서 수동으로 채웠습니다 😅

그리고 기본 **input** 태그를 상속받아서 확장성이 높은 컴포넌트로 만들어보았습니다. (예를 들어 **autoFocus** 같은거 그냥 props 로 넣을 수 있음)

필요한 props 는 스토리북에서 확인하시면 됩니다!

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/ec9d64b0-f4fa-440d-a5cd-c24f7f3da7a4">

### 2. Textarea

**Textarea** 도 필요해서 만들어보았습니다. 얘도 **Input** 이랑 비슷하긴해요

<img width="1043" alt="image" src="https://github.com/user-attachments/assets/8d38579c-490e-4095-b503-3cec4b5a4e3d">

### 3. Field Wrapper

input 과 textarea 의 **label** 과 **error message** 가 포함되어 있습니다.

<img width="1042" alt="image" src="https://github.com/user-attachments/assets/47322179-09b5-460b-be69-2bc54f41dddc">

### 4. useToggle

지난 프로젝트때 제가 만들었던거 그대로 가져왔습니다. 모달, 드롭다운 등등 다양한 상황에서 쓰일 수 있어요

## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->

부족한 부분, 바꾸면 좋을 거 같은 부분, 궁금한 부분 말씀해주세요!
