### PR TITLE
✨Feat(#8) 공용모달컴포넌트

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -56,7 +56,9 @@
     "import/order": "off",
     "react/function-component-definition": "off",
     "react/require-default-props": "off",
-    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+    "jsx-a11y/no-static-element-interactions": "off",
+    "jsx-a11y/click-events-have-key-events": "off"
   },
   "settings": {
     "react": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -55,7 +55,8 @@
     "simple-import-sort/exports": "error",
     "import/order": "off",
     "react/function-component-definition": "off",
-    "react/require-default-props": "off"
+    "react/require-default-props": "off",
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
   },
   "settings": {
     "react": {

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import clsx from "clsx";
+import { AnimatePresence, motion } from "framer-motion";
 import React, { ReactNode, useRef } from "react";
 import { createPortal } from "react-dom";
 
@@ -28,12 +29,14 @@ export interface ModalProps {
   description?: string;
 
   /**
-   * 모달 닫기 버튼의 표시 여부를 설정합니다. 기본설정은 `false`입니다.
+   * 모달 닫기 버튼의 표시 여부를 설정합니다.
+   * 기본설정은 `false`입니다.
    */
   showCloseButton?: boolean;
 
   /**
-   * 경고 아이콘의 표시 여부를 설정합니다. 기본설정은 `false`입니다.
+   * 경고 아이콘의 표시 여부를 설정합니다.
+   * 기본설정은 `false`입니다.
    */
   showWarningIcon?: boolean;
 
@@ -47,6 +50,40 @@ export interface ModalProps {
    */
   children?: ReactNode;
 }
+
+const modalVariants = {
+  hidden: {
+    opacity: 0,
+    scale: 0.9,
+    y: -20,
+  },
+  visible: {
+    opacity: 1,
+    scale: 1,
+    y: 0,
+    transition: {
+      type: "spring",
+      damping: 20,
+      stiffness: 300,
+      mass: 0.5,
+    },
+  },
+  exit: {
+    opacity: 0,
+    scale: 0.95,
+    transition: {
+      type: "tween",
+      ease: "easeInOut",
+      duration: 0.2,
+    },
+  },
+};
+
+const overlayVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { duration: 0.2 } },
+  exit: { opacity: 0, transition: { duration: 0.2 } },
+};
 
 /**
  * 모달 컴포넌트입니다.
@@ -73,58 +110,73 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   const modalRef = useRef<HTMLDivElement>(null);
 
-  if (!isOpen) return null;
-
   const titleMarginClass = description ? "mb-8" : "mb-24";
 
   return createPortal(
-    <div
-      ref={modalRef}
-      onClick={(e) => e.target === modalRef.current && onClose()}
-      className="fixed inset-0 z-50 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50"
-    >
-      <div
-        className={clsx(
-          "z-51 relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
-          className,
-        )}
-      >
-        {showCloseButton && (
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
+    <AnimatePresence>
+      {isOpen && (
+        <motion.div
+          ref={modalRef}
+          onClick={(e) => e.target === modalRef.current && onClose()}
+          className="fixed inset-0 z-50 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50"
+          variants={overlayVariants}
+          initial="hidden"
+          animate="visible"
+          exit="exit"
+        >
+          <motion.div
+            className={clsx(
+              "z-51 relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
+              className,
+            )}
+            variants={modalVariants}
+            initial="hidden"
+            animate="visible"
+            exit="exit"
           >
-            <IconX width={20} height={20} />
-          </button>
-        )}
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
+              >
+                <IconX
+                  width={20}
+                  height={20}
+                  className="text-gray-500 transition-colors duration-200 hover:text-blue-500"
+                  transition-colors
+                />
+              </button>
+            )}
 
-        <div className="flex flex-col items-center">
-          {showWarningIcon && (
-            <div className="mb-16">
-              <IconAlert width={24} height={24} />
-            </div>
-          )}
-
-          {title && (
-            <h2
-              className={clsx(
-                "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
-                titleMarginClass,
+            <div className="flex flex-col items-center">
+              {showWarningIcon && (
+                <div className="mb-16">
+                  <IconAlert width={24} height={24} />
+                </div>
               )}
-            >
-              {title}
-            </h2>
-          )}
-          {description && (
-            <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
-              {description}
-            </p>
-          )}
-          {children}
-        </div>
-      </div>
-    </div>,
+
+              {title && (
+                <h2
+                  className={clsx(
+                    "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
+                    titleMarginClass,
+                  )}
+                >
+                  {title}
+                </h2>
+              )}
+              {description && (
+                <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
+                  {description}
+                </p>
+              )}
+              {children}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>,
     document.body,
   );
 };

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import React, { ReactNode } from "react";
+import { createPortal } from "react-dom";
 
 import { IconAlert, IconX } from "@/public/assets/icons";
 
@@ -24,55 +25,56 @@ const Modal: React.FC<ModalProps> = ({
   className,
   children,
 }) => {
-  if (!isOpen) return null;
-
   const titleMarginClass = description ? "mb-8" : "mb-24";
 
-  return (
-    <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50">
-      <div
-        className={clsx(
-          "relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
-          className,
-        )}
-      >
-        {showCloseButton && (
-          <button
-            type="button"
-            onClick={onClose}
-            className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
+  return isOpen
+    ? createPortal(
+        <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50">
+          <div
+            className={clsx(
+              "relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
+              className,
+            )}
           >
-            <IconX width={20} height={20} />
-          </button>
-        )}
+            {showCloseButton && (
+              <button
+                type="button"
+                onClick={onClose}
+                className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
+              >
+                <IconX width={20} height={20} />
+              </button>
+            )}
 
-        <div className="flex flex-col items-center">
-          {showWarningIcon && (
-            <div className="mb-16">
-              <IconAlert width={24} height={24} />
-            </div>
-          )}
-
-          {title && (
-            <h2
-              className={clsx(
-                "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
-                titleMarginClass,
+            <div className="flex flex-col items-center">
+              {showWarningIcon && (
+                <div className="mb-16">
+                  <IconAlert width={24} height={24} />
+                </div>
               )}
-            >
-              {title}
-            </h2>
-          )}
-          {description && (
-            <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
-              {description}
-            </p>
-          )}
-          {children}
-        </div>
-      </div>
-    </div>
-  );
+
+              {title && (
+                <h2
+                  className={clsx(
+                    "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
+                    titleMarginClass,
+                  )}
+                >
+                  {title}
+                </h2>
+              )}
+              {description && (
+                <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
+                  {description}
+                </p>
+              )}
+              {children}
+            </div>
+          </div>
+        </div>,
+        document.body,
+      )
+    : null;
 };
 
 export default Modal;

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -26,7 +26,7 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   if (!isOpen) return null;
 
-  const getTitleMarginClass = () => (description ? "mb-8" : "mb-24");
+  const titleMarginClass = description ? "mb-8" : "mb-24";
 
   return (
     <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50">
@@ -57,7 +57,7 @@ const Modal: React.FC<ModalProps> = ({
             <h2
               className={clsx(
                 "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
-                getTitleMarginClass(),
+                titleMarginClass,
               )}
             >
               {title}

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -1,5 +1,7 @@
+"use client";
+
 import clsx from "clsx";
-import React, { ReactNode } from "react";
+import React, { ReactNode, useRef } from "react";
 import { createPortal } from "react-dom";
 
 import { IconAlert, IconX } from "@/public/assets/icons";
@@ -25,56 +27,62 @@ const Modal: React.FC<ModalProps> = ({
   className,
   children,
 }) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  if (!isOpen) return null;
+
   const titleMarginClass = description ? "mb-8" : "mb-24";
 
-  return isOpen
-    ? createPortal(
-        <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50">
-          <div
-            className={clsx(
-              "relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
-              className,
-            )}
+  return createPortal(
+    <div
+      ref={modalRef}
+      onClick={(e) => e.target === modalRef.current && onClose()}
+      className="fixed inset-0 z-50 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50" // z-50 추가
+    >
+      <div
+        className={clsx(
+          "z-51 relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg", // z-51 추가
+          className,
+        )}
+      >
+        {showCloseButton && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
           >
-            {showCloseButton && (
-              <button
-                type="button"
-                onClick={onClose}
-                className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
-              >
-                <IconX width={20} height={20} />
-              </button>
-            )}
+            <IconX width={20} height={20} />
+          </button>
+        )}
 
-            <div className="flex flex-col items-center">
-              {showWarningIcon && (
-                <div className="mb-16">
-                  <IconAlert width={24} height={24} />
-                </div>
-              )}
-
-              {title && (
-                <h2
-                  className={clsx(
-                    "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
-                    titleMarginClass,
-                  )}
-                >
-                  {title}
-                </h2>
-              )}
-              {description && (
-                <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
-                  {description}
-                </p>
-              )}
-              {children}
+        <div className="flex flex-col items-center">
+          {showWarningIcon && (
+            <div className="mb-16">
+              <IconAlert width={24} height={24} />
             </div>
-          </div>
-        </div>,
-        document.body,
-      )
-    : null;
+          )}
+
+          {title && (
+            <h2
+              className={clsx(
+                "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
+                titleMarginClass,
+              )}
+            >
+              {title}
+            </h2>
+          )}
+          {description && (
+            <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
+              {description}
+            </p>
+          )}
+          {children}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
 };
 
 export default Modal;

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -1,0 +1,81 @@
+import clsx from "clsx";
+import React, { ReactNode } from "react";
+
+import { IconAlert, IconX } from "@/public/assets/icons";
+
+export interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description?: string;
+  showCloseButton?: boolean;
+  showWarningIcon?: boolean;
+  className?: string;
+  children?: ReactNode;
+}
+
+const Modal: React.FC<ModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+  showCloseButton = false,
+  showWarningIcon = false,
+  className,
+  children,
+}) => {
+  if (!isOpen) return null;
+
+  const getTitleMarginClass = () => {
+    if (description) return "mb-8";
+    return children ? "mb-16" : "mb-24"; // 인풋이나 textArea 가 있을 경우를 피그마 시안보고 고려
+  };
+
+  return (
+    <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary bg-opacity-50">
+      <div
+        className={clsx(
+          "relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
+          className,
+        )}
+      >
+        {showCloseButton && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-12 top-12 text-text-secondary hover:text-text-primary"
+          >
+            <IconX width={20} height={20} />
+          </button>
+        )}
+
+        <div className="flex flex-col items-center">
+          {showWarningIcon && (
+            <div className="mb-16">
+              <IconAlert width={24} height={24} />
+            </div>
+          )}
+
+          {title && (
+            <h2
+              className={clsx(
+                "font-pretendard leading-19 text-center text-16 font-medium text-text-primary",
+                getTitleMarginClass(),
+              )}
+            >
+              {title}
+            </h2>
+          )}
+          {description && (
+            <p className="font-pretendard leading-17 mb-24 text-center text-14 font-medium text-text-secondary">
+              {description}
+            </p>
+          )}
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Modal;

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -26,10 +26,7 @@ const Modal: React.FC<ModalProps> = ({
 }) => {
   if (!isOpen) return null;
 
-  const getTitleMarginClass = () => {
-    if (description) return "mb-8";
-    return children ? "mb-16" : "mb-24"; // 인풋이나 textArea 가 있을 경우를 피그마 시안보고 고려
-  };
+  const getTitleMarginClass = () => (description ? "mb-8" : "mb-24");
 
   return (
     <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50">

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -32,7 +32,7 @@ const Modal: React.FC<ModalProps> = ({
   };
 
   return (
-    <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary bg-opacity-50">
+    <div className="fixed inset-0 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50">
       <div
         className={clsx(
           "relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",

--- a/src/components/common/modal/common-modal.tsx
+++ b/src/components/common/modal/common-modal.tsx
@@ -7,16 +7,60 @@ import { createPortal } from "react-dom";
 import { IconAlert, IconX } from "@/public/assets/icons";
 
 export interface ModalProps {
+  /**
+   * 모달의 열림/닫힘 상태를 제어합니다.
+   */
   isOpen: boolean;
+
+  /**
+   * 모달이 닫힐 때 호출되는 함수입니다.
+   */
   onClose: () => void;
+
+  /**
+   * 모달의 제목을 설정합니다.
+   */
   title: string;
+
+  /**
+   * 모달의 설명 텍스트를 설정합니다.
+   */
   description?: string;
+
+  /**
+   * 모달 닫기 버튼의 표시 여부를 설정합니다. 기본설정은 `false`입니다.
+   */
   showCloseButton?: boolean;
+
+  /**
+   * 경고 아이콘의 표시 여부를 설정합니다. 기본설정은 `false`입니다.
+   */
   showWarningIcon?: boolean;
+
+  /**
+   * 모달에 추가적인 CSS 클래스를 적용합니다.
+   */
   className?: string;
+
+  /**
+   * 모달 내부에 표시될 자식 컴포넌트들입니다.
+   */
   children?: ReactNode;
 }
 
+/**
+ * 모달 컴포넌트입니다.
+ * 페이지 위에 오버레이와 함께 내용을 표시합니다.
+ * `isOpen`,
+  `onClose`,
+  `title`,
+  `description`,
+  `showCloseButton` = `false`,
+  `showWarningIcon` = `false`,
+  `className`,
+  `children`,
+  속성이 있습니다.
+ */
 const Modal: React.FC<ModalProps> = ({
   isOpen,
   onClose,
@@ -37,11 +81,11 @@ const Modal: React.FC<ModalProps> = ({
     <div
       ref={modalRef}
       onClick={(e) => e.target === modalRef.current && onClose()}
-      className="fixed inset-0 z-50 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50" // z-50 추가
+      className="fixed inset-0 z-50 flex size-full items-center justify-center overflow-y-auto bg-background-primary/50"
     >
       <div
         className={clsx(
-          "z-51 relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg", // z-51 추가
+          "z-51 relative w-384 rounded-8 bg-background-secondary px-48 pb-32 pt-48 shadow-lg",
           className,
         )}
       >

--- a/src/components/common/modal/modal.stories.tsx
+++ b/src/components/common/modal/modal.stories.tsx
@@ -1,0 +1,90 @@
+/* eslint-disable */
+import React from "react";
+import type { Meta, StoryObj } from "@storybook/react";
+import Modal, { ModalProps } from "./common-modal";
+
+const meta: Meta<typeof Modal> = {
+  title: "Components/Modal",
+  component: Modal,
+  tags: ["autodocs"],
+  argTypes: {
+    isOpen: { control: "boolean" },
+    onClose: { action: "닫힘" },
+    title: { control: "text" },
+    description: { control: "text" },
+    showCloseButton: { control: "boolean" },
+    showWarningIcon: { control: "boolean" },
+    className: { control: "text" },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Modal>;
+
+const ModalWrapper: React.FC<ModalProps> = (args) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  return (
+    <div>
+      <button
+        onClick={() => setIsOpen(true)}
+        className="bg-brand-primary hover:bg-interaction-hover text-white font-bold py-2 px-4 rounded"
+      >
+        모달 열기
+      </button>
+      <Modal
+        {...args}
+        isOpen={isOpen}
+        onClose={() => {
+          setIsOpen(false);
+          args.onClose?.();
+        }}
+      />
+    </div>
+  );
+};
+
+export const Default: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    title: "기본 모달",
+    description: "이것은 기본 모달입니다.",
+    showCloseButton: true,
+  },
+};
+
+export const WithWarningIcon: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    title: "경고 모달",
+    description: "이것은 경고 아이콘이 있는 모달입니다.",
+    showCloseButton: true,
+    showWarningIcon: true,
+  },
+};
+
+export const CustomStyle: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    title: "커스텀 스타일 모달",
+    description: "클레스네임으로 디자인 수정가능합니다",
+    showCloseButton: true,
+    className: "bg-brand-primary border-2 border-blue-500",
+  },
+};
+
+export const TitleOnly: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    title: "제목만 있는 모달",
+    showCloseButton: true,
+  },
+};
+
+export const DescriptionOnly: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    description: "설명만 있는 모달입니다.",
+    showCloseButton: true,
+  },
+};

--- a/src/components/common/modal/modal.stories.tsx
+++ b/src/components/common/modal/modal.stories.tsx
@@ -100,13 +100,3 @@ export const NoCloseButton: Story = {
     showCloseButton: false,
   },
 };
-
-export const CloseOnlyByExternalClick: Story = {
-  render: (args) => <ModalWrapper {...args} />,
-  args: {
-    title: "외부 클릭으로만 닫기",
-    description:
-      "이 모달은 외부 클릭으로만 닫을 수 있습니다. 닫기 버튼이 없습니다.",
-    showCloseButton: false,
-  },
-};

--- a/src/components/common/modal/modal.stories.tsx
+++ b/src/components/common/modal/modal.stories.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable */
-import React from "react";
 import type { Meta, StoryObj } from "@storybook/react";
+import React from "react";
+
 import Modal, { ModalProps } from "./common-modal";
 
 const meta: Meta<typeof Modal> = {
@@ -8,12 +9,46 @@ const meta: Meta<typeof Modal> = {
   component: Modal,
   tags: ["autodocs"],
   argTypes: {
+    /**
+     * isOpen: 모달의 열림/닫힘 상태를 제어합니다.
+     * true면 모달이 열리고, false면 닫힙니다.
+     */
     isOpen: { control: "boolean" },
+
+    /**
+     * onClose: 모달이 닫힐 때 호출되는 함수입니다.
+     * 모달 닫기 버튼 클릭이나 외부 클릭 시 실행됩니다.
+     */
     onClose: { action: "닫힘" },
+
+    /**
+     * title: 모달의 제목을 설정합니다.
+     * 모달 상단에 표시됩니다.
+     */
     title: { control: "text" },
+
+    /**
+     * description: 모달의 본문 내용을 설정합니다.
+     * 제목 아래에 표시됩니다.
+     */
     description: { control: "text" },
+
+    /**
+     * showCloseButton: 모달 닫기 버튼의 표시 여부를 설정합니다.
+     * true면 닫기 버튼이 표시되고, false면 숨겨집니다.
+     */
     showCloseButton: { control: "boolean" },
+
+    /**
+     * showWarningIcon: 경고 아이콘의 표시 여부를 설정합니다.
+     * true면 경고 아이콘이 표시되고, false면 표시되지 않습니다.
+     */
     showWarningIcon: { control: "boolean" },
+
+    /**
+     * className: 모달에 추가적인 CSS 클래스를 적용합니다.
+     * 커스텀 스타일링을 위해 사용됩니다.
+     */
     className: { control: "text" },
   },
 };
@@ -28,7 +63,7 @@ const ModalWrapper: React.FC<ModalProps> = (args) => {
     <div>
       <button
         onClick={() => setIsOpen(true)}
-        className="bg-brand-primary hover:bg-interaction-hover text-white font-bold py-2 px-4 rounded"
+        className="rounded bg-brand-primary px-4 py-2 font-bold text-white hover:bg-interaction-hover"
       >
         모달 열기
       </button>
@@ -48,7 +83,7 @@ export const Default: Story = {
   render: (args) => <ModalWrapper {...args} />,
   args: {
     title: "기본 모달",
-    description: "이것은 기본 모달입니다.",
+    description: "이것은 기본 모달입니다. 외부 클릭으로 닫을 수 있습니다.",
     showCloseButton: true,
   },
 };
@@ -57,7 +92,8 @@ export const WithWarningIcon: Story = {
   render: (args) => <ModalWrapper {...args} />,
   args: {
     title: "경고 모달",
-    description: "이것은 경고 아이콘이 있는 모달입니다.",
+    description:
+      "이것은 경고 아이콘이 있는 모달입니다. 외부 클릭으로 닫을 수 있습니다.",
     showCloseButton: true,
     showWarningIcon: true,
   },
@@ -67,7 +103,8 @@ export const CustomStyle: Story = {
   render: (args) => <ModalWrapper {...args} />,
   args: {
     title: "커스텀 스타일 모달",
-    description: "클레스네임으로 디자인 수정가능합니다",
+    description:
+      "클래스네임으로 디자인 수정 가능합니다. 외부 클릭으로 닫을 수 있습니다.",
     showCloseButton: true,
     className: "bg-brand-primary border-2 border-blue-500",
   },
@@ -84,7 +121,26 @@ export const TitleOnly: Story = {
 export const DescriptionOnly: Story = {
   render: (args) => <ModalWrapper {...args} />,
   args: {
-    description: "설명만 있는 모달입니다.",
+    description: "설명만 있는 모달입니다. 외부 클릭으로 닫을 수 있습니다.",
     showCloseButton: true,
+  },
+};
+
+export const NoCloseButton: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    title: "닫기 버튼 없는 모달",
+    description: "닫기 버튼이 없지만, 외부 클릭으로 닫을 수 있습니다.",
+    showCloseButton: false,
+  },
+};
+
+export const CloseOnlyByExternalClick: Story = {
+  render: (args) => <ModalWrapper {...args} />,
+  args: {
+    title: "외부 클릭으로만 닫기",
+    description:
+      "이 모달은 외부 클릭으로만 닫을 수 있습니다. 닫기 버튼이 없습니다.",
+    showCloseButton: false,
   },
 };

--- a/src/components/common/modal/modal.stories.tsx
+++ b/src/components/common/modal/modal.stories.tsx
@@ -9,46 +9,12 @@ const meta: Meta<typeof Modal> = {
   component: Modal,
   tags: ["autodocs"],
   argTypes: {
-    /**
-     * isOpen: 모달의 열림/닫힘 상태를 제어합니다.
-     * true면 모달이 열리고, false면 닫힙니다.
-     */
     isOpen: { control: "boolean" },
-
-    /**
-     * onClose: 모달이 닫힐 때 호출되는 함수입니다.
-     * 모달 닫기 버튼 클릭이나 외부 클릭 시 실행됩니다.
-     */
     onClose: { action: "닫힘" },
-
-    /**
-     * title: 모달의 제목을 설정합니다.
-     * 모달 상단에 표시됩니다.
-     */
     title: { control: "text" },
-
-    /**
-     * description: 모달의 본문 내용을 설정합니다.
-     * 제목 아래에 표시됩니다.
-     */
     description: { control: "text" },
-
-    /**
-     * showCloseButton: 모달 닫기 버튼의 표시 여부를 설정합니다.
-     * true면 닫기 버튼이 표시되고, false면 숨겨집니다.
-     */
     showCloseButton: { control: "boolean" },
-
-    /**
-     * showWarningIcon: 경고 아이콘의 표시 여부를 설정합니다.
-     * true면 경고 아이콘이 표시되고, false면 표시되지 않습니다.
-     */
     showWarningIcon: { control: "boolean" },
-
-    /**
-     * className: 모달에 추가적인 CSS 클래스를 적용합니다.
-     * 커스텀 스타일링을 위해 사용됩니다.
-     */
     className: { control: "text" },
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,8 @@
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".eslintrc.json",
-    "postcss.config.mjs"
+    "postcss.config.mjs",
+    "next.config.mjs"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION


## #️⃣ 이슈

- close #8 

## 📝 작업 내용

공용모달 컴포넌트를 제작했습니다

## 📸 결과물
![image](https://github.com/user-attachments/assets/46c3ac01-ceb0-4f85-92a5-2581089162ee)

![image](https://github.com/user-attachments/assets/82276b9a-310e-425f-80f1-070d45955065)

![image](https://github.com/user-attachments/assets/3d9bccc5-1ae3-4aa7-8b4c-f486de392eca)


## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항
로컬동작 확인은 테스트 페이지에서 확인후 삭제하여 PR을 올렸습니다(스토리북에서 확인 가능합니다!)

경고모달과 일반모달을 나눌려했는데 그냥 아이콘 자체를 프롭으로 넘기는게 더 편할거같아서 아이콘까지는 프롭으로 넣었습니다

title과 description 은 기본으로 들어가있는데 피그마를 보면 description이 있을때와 없을때 제목과 컨텐츠 사이에 마진이 달라서 조건부로 넣어줬는데 PR을 올리면서 생각해보니까 children으로 넣는 컨텐츠에서 마진을 조정해도 될거같네요...

![image](https://github.com/user-attachments/assets/e933d78c-bd7b-4a5c-beb8-8280d2c29d5a)

![image](https://github.com/user-attachments/assets/91fad365-73ea-4ea4-99b2-aba662b211fd)

