### PR TITLE
💄 Design(#66): 마이리스트페이지 UI 제작

### DIFF
--- a/src/app/(list)/[teamId]/task-lists/[listId]/task-detail/[id]/_components/task-detail/task-content.tsx
+++ b/src/app/(list)/[teamId]/task-lists/[listId]/task-detail/[id]/_components/task-detail/task-content.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import "dayjs/locale/ko";
+
 import dayjs from "dayjs";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";

--- a/src/app/user/history/_components/mock.json
+++ b/src/app/user/history/_components/mock.json
@@ -1,0 +1,127 @@
+{
+  "myHistory": [
+    {
+      "date": "2024년 1월 11일",
+      "tasks": [
+        {
+          "id": 1,
+          "name": "불안-우울 모니터링하기",
+          "description": "",
+          "date": "2024-01-11",
+          "doneAt": "2024-01-11T10:00:00Z",
+          "updatedAt": "2024-01-11T10:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 1,
+          "frequency": "DAILY"
+        },
+        {
+          "id": 2,
+          "name": "증상 변화 모니터링하기",
+          "description": "",
+          "date": "2024-01-11",
+          "doneAt": "2024-01-11T11:00:00Z",
+          "updatedAt": "2024-01-11T11:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 2,
+          "frequency": "DAILY"
+        },
+        {
+          "id": 3,
+          "name": "일상예측-신념변화 바라보고 증거자료서 재출하기",
+          "description": "",
+          "date": "2024-01-11",
+          "doneAt": "2024-01-11T14:00:00Z",
+          "updatedAt": "2024-01-11T14:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 3,
+          "frequency": "DAILY"
+        }
+      ]
+    },
+    {
+      "date": "2024년 1월 10일",
+      "tasks": [
+        {
+          "id": 4,
+          "name": "고객 전화에 어떤 카스털 접근 재공하기",
+          "description": "",
+          "date": "2024-01-10",
+          "doneAt": "2024-01-10T09:00:00Z",
+          "updatedAt": "2024-01-10T09:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 4,
+          "frequency": "DAILY"
+        },
+        {
+          "id": 5,
+          "name": "불안-안전도함, 증거서류, 안정증명서 발급하기",
+          "description": "",
+          "date": "2024-01-10",
+          "doneAt": "2024-01-10T13:00:00Z",
+          "updatedAt": "2024-01-10T13:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 5,
+          "frequency": "DAILY"
+        },
+        {
+          "id": 6,
+          "name": "옆에이트 안 동기부호를 발급하고 영수증 발송하기",
+          "description": "",
+          "date": "2024-01-10",
+          "doneAt": "2024-01-10T16:00:00Z",
+          "updatedAt": "2024-01-10T16:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 6,
+          "frequency": "DAILY"
+        }
+      ]
+    },
+    {
+      "date": "2024년 1월 9일",
+      "tasks": [
+        {
+          "id": 7,
+          "name": "고객 전화에 어떤 카스털 접근 재공하기",
+          "description": "",
+          "date": "2024-01-09",
+          "doneAt": "2024-01-09T09:00:00Z",
+          "updatedAt": "2024-01-09T09:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 4,
+          "frequency": "DAILY"
+        },
+        {
+          "id": 8,
+          "name": "불안-안전도함, 증거서류, 안정증명서 발급하기",
+          "description": "",
+          "date": "2024-01-09",
+          "doneAt": "2024-01-09T13:00:00Z",
+          "updatedAt": "2024-01-09T13:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 5,
+          "frequency": "DAILY"
+        },
+        {
+          "id": 9,
+          "name": "옆에이트 안 동기부호를 발급하고 영수증 발송하기",
+          "description": "",
+          "date": "2024-01-09",
+          "doneAt": "2024-01-09T16:00:00Z",
+          "updatedAt": "2024-01-09T16:00:00Z",
+          "deletedAt": "",
+          "userId": 1,
+          "recurringId": 6,
+          "frequency": "DAILY"
+        }
+      ]
+    }
+  ]
+}

--- a/src/app/user/history/_components/my-history-list.tsx
+++ b/src/app/user/history/_components/my-history-list.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 
-import { IconCheckBoxPrimary, IconKebab } from "@/public/assets/icons";
+import {
+  IconCheckBoxPrimary,
+  IconCheckPrimary,
+  IconKebab,
+} from "@/public/assets/icons";
 import { DayTasks } from "@/types/user-history/index";
 
 interface MyHistoryProps {
@@ -18,9 +22,8 @@ const MyHistory = ({ data }: MyHistoryProps) => (
             key={task.id}
             className="mb-10 flex items-center rounded-8 bg-background-secondary p-10"
           >
-            <IconCheckBoxPrimary className="mr-10 shrink-0" />
+            <IconCheckPrimary className="mr-10 shrink-0" />
             <span className="text-14-500 line-through">{task.name}</span>
-            <IconKebab className="ml-auto shrink-0" />
           </div>
         ))}
       </div>

--- a/src/app/user/history/_components/my-history-list.tsx
+++ b/src/app/user/history/_components/my-history-list.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+import { IconCheckBoxPrimary, IconKebab } from "@/public/assets/icons";
+import { DayTasks } from "@/types/user-history/index";
+
+interface MyHistoryProps {
+  data: DayTasks[];
+}
+
+const MyHistory = ({ data }: MyHistoryProps) => (
+  <div className="bg-gray-900 text-white">
+    <h1 className="mb-24 mt-40 text-20-600 font-bold">마이 히스토리</h1>
+    {data.map((dayTasks) => (
+      <div key={dayTasks.date} className="mb-30">
+        <h2 className="mb-16 text-16-600">{dayTasks.date}</h2>
+        {dayTasks.tasks.map((task) => (
+          <div
+            key={task.id}
+            className="mb-10 flex items-center rounded-8 bg-background-secondary p-10"
+          >
+            <IconCheckBoxPrimary className="mr-10 shrink-0" />
+            <span className="text-14-500 line-through">{task.name}</span>
+            <IconKebab className="ml-auto shrink-0" />
+          </div>
+        ))}
+      </div>
+    ))}
+  </div>
+);
+
+export default MyHistory;

--- a/src/app/user/history/layout.tsx
+++ b/src/app/user/history/layout.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { ReactNode } from "react";
+
+export const metadata: Metadata = {
+  title: "마이히스토리",
+  description: "내 지원정보페이지",
+};
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout = ({ children }: LayoutProps) => (
+  <div className="mx-auto flex flex-col">{children}</div>
+);
+
+export default Layout;

--- a/src/app/user/history/page.tsx
+++ b/src/app/user/history/page.tsx
@@ -1,0 +1,15 @@
+import { MyHistoryData } from "@/types/user-history/index";
+
+import mockData from "./_components/mock.json";
+import MyHistory from "./_components/my-history-list";
+
+const MyHistoryPage = () => {
+  const MyMockData = mockData as MyHistoryData;
+
+  return (
+    <div className="container mx-auto">
+      <MyHistory data={MyMockData.myHistory} />
+    </div>
+  );
+};
+export default MyHistoryPage;

--- a/src/types/user-history/index.ts
+++ b/src/types/user-history/index.ts
@@ -1,0 +1,21 @@
+export type Task = {
+  id: number;
+  name: string;
+  description: string;
+  date: string;
+  doneAt: string;
+  updatedAt: string;
+  deletedAt: string;
+  userId: number;
+  recurringId: number;
+  frequency: string;
+};
+
+export type DayTasks = {
+  date: string;
+  tasks: Task[];
+};
+
+export type MyHistoryData = {
+  myHistory: DayTasks[];
+};


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #59

## 📝 작업 내용

마이 히스토리페이지 UI 제작

## 📸 결과물

![image](https://github.com/user-attachments/assets/b6daf524-5c72-4c79-a594-682d91864fab)


## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

마이히스토리 페이지 데이터를 받아오는 API 를 보면 TaskDone 되어있는것들의 모든 리스트를 받아오는데
팀 상관없이 완료된 task에대한 모든걸 받아오는거 같습니다(1팀 2팀 3팀에서 완료한 모든 task들)
피그마 시안에는 체크박스랑 타코야끼버튼이 있는데
```json
[
  {
    "tasksDone": [
      {
        "deletedAt": "2024-08-06T08:01:31.020Z",
        "userId": 0,
        "recurringId": 0,
        "frequency": "DAILY",
        "date": "2024-08-06T08:01:31.020Z",
        "doneAt": "2024-08-06T08:01:31.020Z",
        "description": "string",
        "name": "string",
        "updatedAt": "2024-08-06T08:01:31.020Z",
        "id": 0
      }
    ]
  }
]
```

리스폰스를 봐도 팀ID에 대한것도 없고 이 체크박스를 눌러서 취소를 하더라도 완료한작업을 취소하는 api 를 사용하기도 어려울거같아서 이 체크박스와 타코야끼 버튼이 있는게 좋을지 없는게 좋을지 의견들 궁금합니다!!

