### PR TITLE
✨ Feat(#106): 비밀번호 재설정 api 구현

### DIFF
--- a/src/app/(auth)/_components/login/signin-form.tsx
+++ b/src/app/(auth)/_components/login/signin-form.tsx
@@ -85,88 +85,93 @@ const SignInForm: React.FC = () => {
   };
 
   return (
-    <form onSubmit={handleSubmit(onSubmit)} className="mt-80 w-315 md:w-470">
-      <p className="mb-80 flex justify-center text-24 font-medium text-text-primary lg:text-40">
-        로그인
-      </p>
-      <FieldWrapper
-        id="email"
-        label="이메일"
-        errorMessage={errors.email?.message || ""}
-      >
-        <Input
-          id="email"
-          type="text"
-          placeholder="이메일을 입력해주세요"
-          {...register("email")}
-          isError={!!errors.email}
-        />
-      </FieldWrapper>
-      <div className="mt-24">
+    <>
+      <form onSubmit={handleSubmit(onSubmit)} className="mt-80 w-315 md:w-470">
+        <p className="mb-80 flex justify-center text-24 font-medium text-text-primary lg:text-40">
+          로그인
+        </p>
         <FieldWrapper
-          id="password"
-          label="비밀번호"
-          errorMessage={errors.password?.message || ""}
+          id="email"
+          label="이메일"
+          errorMessage={errors.email?.message || ""}
         >
           <Input
-            id="password"
-            type="password"
-            placeholder="비밀번호를 입력해주세요"
-            {...register("password")}
-            isError={!!errors.password}
+            id="email"
+            type="text"
+            placeholder="이메일을 입력해주세요"
+            {...register("email")}
+            isError={!!errors.email}
           />
         </FieldWrapper>
-        <div className="mt-12 text-right">
-          <button
-            type="button"
-            className="text-16-500 text-brand-primary underline"
-            onClick={handlePasswordResetClick}
+        <div className="mt-24">
+          <FieldWrapper
+            id="password"
+            label="비밀번호"
+            errorMessage={errors.password?.message || ""}
           >
-            비밀번호를 잊으셨나요?
-          </button>
-          <CommonComponent isOpen={isOpen} onClose={() => setIsOpen(false)} />
+            <Input
+              id="password"
+              type="password"
+              placeholder="비밀번호를 입력해주세요"
+              {...register("password")}
+              isError={!!errors.password}
+            />
+          </FieldWrapper>
+          <div className="mt-12 text-right">
+            <button
+              type="button"
+              className="text-16-500 text-brand-primary underline"
+              onClick={handlePasswordResetClick}
+            >
+              비밀번호를 잊으셨나요?
+            </button>
+          </div>
         </div>
-      </div>
-      <Button
-        variant="primary"
-        type="submit"
-        className="mt-40 h-47 w-full"
-        disabled={!isValid || isLoading}
-      >
-        {isLoading ? "처리 중..." : "로그인"}
-      </Button>
-      <div className="flex justify-center">
-        <p className="mt-24">
-          아직 계정이 없으신가요?
-          <Link href="/sign-up" className="ml-12 text-brand-primary underline">
-            가입하기
-          </Link>
-        </p>
-      </div>
-      <div className="mt-48 flex w-full items-center">
-        <hr className="flex-1 border-t border-border-primary" />
-        <span className="mx-24 text-16-400">OR</span>
-        <hr className="flex-1 border-t border-border-primary" />
-      </div>
-      <div className="mt-16 flex w-full justify-between">
-        <p className=" text-16-500">간편 로그인하기</p>
-        {/* 간편 로그인 작업 예정 */}
-        <div className="flex gap-4">
-          <button
-            type="button"
-            className="flex size-42 items-center justify-center rounded"
-          >
-            <Image src={ImgGoogle} alt="Google" />
-          </button>
-          <button
-            type="button"
-            className="ml-16 flex size-42 items-center justify-center rounded"
-          >
-            <Image src={ImgKakao} alt="Kakao" />
-          </button>
+        <Button
+          variant="primary"
+          type="submit"
+          className="mt-40 h-47 w-full"
+          disabled={!isValid || isLoading}
+        >
+          {isLoading ? "처리 중..." : "로그인"}
+        </Button>
+        <div className="flex justify-center">
+          <p className="mt-24">
+            아직 계정이 없으신가요?
+            <Link
+              href="/sign-up"
+              className="ml-12 text-brand-primary underline"
+            >
+              가입하기
+            </Link>
+          </p>
         </div>
-      </div>
-    </form>
+        <div className="mt-48 flex w-full items-center">
+          <hr className="flex-1 border-t border-border-primary" />
+          <span className="mx-24 text-16-400">OR</span>
+          <hr className="flex-1 border-t border-border-primary" />
+        </div>
+        <div className="mt-16 flex w-full justify-between">
+          <p className=" text-16-500">간편 로그인하기</p>
+          {/* 간편 로그인 작업 예정 */}
+          <div className="flex gap-4">
+            <button
+              type="button"
+              className="flex size-42 items-center justify-center rounded"
+            >
+              <Image src={ImgGoogle} alt="Google" />
+            </button>
+            <button
+              type="button"
+              className="ml-16 flex size-42 items-center justify-center rounded"
+            >
+              <Image src={ImgKakao} alt="Kakao" />
+            </button>
+          </div>
+        </div>
+      </form>
+      <CommonComponent isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
   );
 };
 

--- a/src/app/(auth)/_components/login/signin-form.tsx
+++ b/src/app/(auth)/_components/login/signin-form.tsx
@@ -10,18 +10,24 @@ import { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { Button, FieldWrapper, Input } from "@/components/common";
-import { useToast } from "@/hooks";
+import { useIsMobile, useToast } from "@/hooks";
 import signIn from "@/lib/api/auth/sign-in";
 import { loginSchema } from "@/lib/schemas/auth";
 import { ImgGoogle, ImgKakao } from "@/public/assets/images";
 import userAtom from "@/stores/user-atom";
 import { SignInInput } from "@/types/auth";
 
+import ResetPasswordDrawer from "../reset-password/reset-password-drawer";
+import ResetPasswordModal from "../reset-password/reset-password-modal";
+
 const SignInForm: React.FC = () => {
   const router = useRouter();
   const { success, error } = useToast();
   const [isLoading, setIsLoading] = useState(false);
   const [, setUser] = useAtom(userAtom);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const isMobile = useIsMobile();
 
   const queryClient = useQueryClient();
 
@@ -72,6 +78,12 @@ const SignInForm: React.FC = () => {
     }
   };
 
+  const CommonComponent = isMobile ? ResetPasswordDrawer : ResetPasswordModal;
+
+  const handlePasswordResetClick = () => {
+    setIsOpen(true);
+  };
+
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="mt-80 w-315 md:w-470">
       <p className="mb-80 flex justify-center text-24 font-medium text-text-primary lg:text-40">
@@ -104,9 +116,16 @@ const SignInForm: React.FC = () => {
             isError={!!errors.password}
           />
         </FieldWrapper>
-        <p className="mt-12 text-right text-16-500 text-brand-primary underline">
-          <Link href="/reset-password">비밀번호를 잊으셨나요?</Link>
-        </p>
+        <div className="mt-12 text-right">
+          <button
+            type="button"
+            className="text-16-500 text-brand-primary underline"
+            onClick={handlePasswordResetClick}
+          >
+            비밀번호를 잊으셨나요?
+          </button>
+          <CommonComponent isOpen={isOpen} onClose={() => setIsOpen(false)} />
+        </div>
       </div>
       <Button
         variant="primary"

--- a/src/app/(auth)/_components/reset-password/reset-password-drawer.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-drawer.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -7,6 +5,8 @@ import { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { Button, Drawer, FieldWrapper, Input } from "@/components/common";
+import { useToast } from "@/hooks";
+import SendEmail from "@/lib/api/reset-password/send-email";
 import { emailSchema } from "@/lib/schemas/auth";
 import { EmailInput } from "@/types/auth";
 
@@ -17,6 +17,7 @@ interface ResetPasswordDrawerProps {
 
 const ResetPasswordDrawer = ({ isOpen, onClose }: ResetPasswordDrawerProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const { success, error } = useToast();
 
   const {
     register,
@@ -28,21 +29,20 @@ const ResetPasswordDrawer = ({ isOpen, onClose }: ResetPasswordDrawerProps) => {
     reValidateMode: "onChange",
   });
 
-  // NOTE - api 작업 대신 넣었습니다.
   const onSubmit: SubmitHandler<EmailInput> = async ({ email }) => {
     setIsLoading(true);
 
-    setTimeout(() => {
-      const success = true;
+    const redirectUrl = "https://3team-coworkers.netlify.app";
 
-      if (success) {
-        console.log("성공");
-      } else {
-        console.log("실패");
-      }
+    const { success: apiSuccess, data } = await SendEmail(email, redirectUrl);
 
-      setIsLoading(false);
-    }, 1000);
+    if (apiSuccess) {
+      success(data.message);
+    } else {
+      error(data.message);
+    }
+
+    setIsLoading(false);
   };
 
   return (

--- a/src/app/(auth)/_components/reset-password/reset-password-drawer.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-drawer.tsx
@@ -32,7 +32,8 @@ const ResetPasswordDrawer = ({ isOpen, onClose }: ResetPasswordDrawerProps) => {
   const onSubmit: SubmitHandler<EmailInput> = async ({ email }) => {
     setIsLoading(true);
 
-    const redirectUrl = "https://3team-coworkers.netlify.app";
+    // NOTE - 배포 주소로 변경 예정
+    const redirectUrl = "http://localhost:3000";
 
     const { success: apiSuccess, data } = await SendEmail(email, redirectUrl);
 

--- a/src/app/(auth)/_components/reset-password/reset-password-form.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-form.tsx
@@ -9,9 +9,6 @@ import { useIsMobile } from "@/hooks";
 import { resetPasswordSchema } from "@/lib/schemas/auth";
 import { ResetPasswordInput } from "@/types/auth";
 
-import ResetPasswordDrawer from "./reset-password-drawer";
-import ResetPasswordModal from "./reset-password-modal";
-
 const ResetPasswordForm: React.FC = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -47,64 +44,51 @@ const ResetPasswordForm: React.FC = () => {
   };
 
   return (
-    <>
-      <form onSubmit={handleSubmit(onSubmit)} className="mt-80 w-315 md:w-470">
-        <h1 className="mb-80 flex justify-center text-24 font-medium text-text-primary lg:text-40">
-          비밀번호 재설정
-        </h1>
-        <FieldWrapper
+    <form onSubmit={handleSubmit(onSubmit)} className="mt-80 w-315 md:w-470">
+      <h1 className="mb-80 flex justify-center text-24 font-medium text-text-primary lg:text-40">
+        비밀번호 재설정
+      </h1>
+      <FieldWrapper
+        id="newpassword"
+        label="새 비밀번호"
+        errorMessage={errors.password?.message || ""}
+      >
+        <Input
           id="newpassword"
-          label="새 비밀번호"
-          errorMessage={errors.password?.message || ""}
+          type="password"
+          placeholder={
+            isMobile
+              ? "비밀번호를 입력해주세요"
+              : "비밀번호(영문, 숫자, 특수문자 포함, 최소 8자)를 입력해주세요."
+          }
+          {...register("password")}
+          isError={!!errors.password}
+        />
+      </FieldWrapper>
+      <div className="mt-24">
+        <FieldWrapper
+          id="passwordConfirmation"
+          label="비밀번호 확인"
+          errorMessage={errors.passwordConfirmation?.message || ""}
         >
           <Input
-            id="newpassword"
+            id="passwordConfirmation"
             type="password"
-            placeholder={
-              isMobile
-                ? "비밀번호를 입력해주세요"
-                : "비밀번호(영문, 숫자, 특수문자 포함, 최소 8자)를 입력해주세요."
-            }
-            {...register("password")}
-            isError={!!errors.password}
+            placeholder="새 비밀번호를 다시 한 번 입력해주세요"
+            {...register("passwordConfirmation")}
+            isError={!!errors.passwordConfirmation}
           />
         </FieldWrapper>
-        <div className="mt-24">
-          <FieldWrapper
-            id="passwordConfirmation"
-            label="비밀번호 확인"
-            errorMessage={errors.passwordConfirmation?.message || ""}
-          >
-            <Input
-              id="passwordConfirmation"
-              type="password"
-              placeholder="새 비밀번호를 다시 한 번 입력해주세요"
-              {...register("passwordConfirmation")}
-              isError={!!errors.passwordConfirmation}
-            />
-          </FieldWrapper>
-        </div>
-        <Button
-          variant="primary"
-          type="submit"
-          className="mt-40 h-47 w-full"
-          disabled={!isValid || isLoading}
-        >
-          재설정
-        </Button>
-      </form>
-      {isMobile ? (
-        <ResetPasswordDrawer
-          isOpen={isDrawerOpen}
-          onClose={() => setIsDrawerOpen(false)}
-        />
-      ) : (
-        <ResetPasswordModal
-          isOpen={isModalOpen}
-          onClose={() => setIsModalOpen(false)}
-        />
-      )}
-    </>
+      </div>
+      <Button
+        variant="primary"
+        type="submit"
+        className="mt-40 h-47 w-full"
+        disabled={!isValid || isLoading}
+      >
+        재설정
+      </Button>
+    </form>
   );
 };
 

--- a/src/app/(auth)/_components/reset-password/reset-password-modal.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-modal.tsx
@@ -32,7 +32,8 @@ const ResetPasswordModal = ({ isOpen, onClose }: ResetPasswordModalProps) => {
   const onSubmit: SubmitHandler<EmailInput> = async ({ email }) => {
     setIsLoading(true);
 
-    const redirectUrl = "https://3team-coworkers.netlify.app";
+    // NOTE - 배포 주소로 변경 예정
+    const redirectUrl = "http://localhost:3000";
 
     const { success: apiSuccess, data } = await SendEmail(email, redirectUrl);
 

--- a/src/app/(auth)/_components/reset-password/reset-password-modal.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-modal.tsx
@@ -7,6 +7,8 @@ import { useState } from "react";
 import { SubmitHandler, useForm } from "react-hook-form";
 
 import { Button, FieldWrapper, Input, Modal } from "@/components/common";
+import { useToast } from "@/hooks";
+import SendEmail from "@/lib/api/reset-password/send-email";
 import { emailSchema } from "@/lib/schemas/auth";
 import { EmailInput } from "@/types/auth";
 
@@ -17,6 +19,7 @@ interface ResetPasswordModalProps {
 
 const ResetPasswordModal = ({ isOpen, onClose }: ResetPasswordModalProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const { success, error } = useToast();
 
   const {
     register,
@@ -28,21 +31,20 @@ const ResetPasswordModal = ({ isOpen, onClose }: ResetPasswordModalProps) => {
     reValidateMode: "onChange",
   });
 
-  // NOTE - api 작업 대신 넣었습니다.
   const onSubmit: SubmitHandler<EmailInput> = async ({ email }) => {
     setIsLoading(true);
 
-    setTimeout(() => {
-      const success = true;
+    const redirectUrl = "https://3team-coworkers.netlify.app";
 
-      if (success) {
-        console.log("성공");
-      } else {
-        console.log("실패");
-      }
+    const { success: apiSuccess, data } = await SendEmail(email, redirectUrl);
 
-      setIsLoading(false);
-    }, 1000);
+    if (apiSuccess) {
+      success(data.message);
+    } else {
+      error(data.message);
+    }
+
+    setIsLoading(false);
   };
 
   return (

--- a/src/app/(auth)/_components/reset-password/reset-password-modal.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-modal.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable no-console */
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/src/lib/api/reset-password/reset-password.ts
+++ b/src/lib/api/reset-password/reset-password.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import axios from "axios";
+
+import instance from "@/lib/api/axios-instance";
+
+const ResetPassword = async (
+  passwordConfirmation: string,
+  password: string,
+  token: string,
+) => {
+  try {
+    const response = await instance.patch(`/user/reset-password`, {
+      passwordConfirmation,
+      password,
+      token,
+    });
+
+    if (response.status === 200) {
+      return { success: true, data: response.data };
+    }
+    return { success: false, data: response.data };
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      if (error.response.status === 400) {
+        return {
+          success: false,
+          data: error.response.data,
+        };
+      }
+      return {
+        success: false,
+        data: error.response.data,
+      };
+    }
+
+    return {
+      success: false,
+      data: {
+        message: "비밀번호 재설정 중 오류가 발생했습니다.",
+      },
+    };
+  }
+};
+
+export default ResetPassword;

--- a/src/lib/api/reset-password/reset-password.ts
+++ b/src/lib/api/reset-password/reset-password.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import axios from "axios";
 
 import instance from "@/lib/api/axios-instance";

--- a/src/lib/api/reset-password/send-email.ts
+++ b/src/lib/api/reset-password/send-email.ts
@@ -1,0 +1,35 @@
+"use server";
+
+import axios from "axios";
+
+import instance from "@/lib/api/axios-instance";
+
+const SendEmail = async (email: string, redirectUrl: string) => {
+  try {
+    const response = await instance.post(`/user/send-reset-password-email`, {
+      email,
+      redirectUrl,
+    });
+
+    if (response.status === 200) {
+      return { success: true, data: response.data };
+    }
+    return { success: false, data: response.data };
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      return {
+        success: false,
+        data: error.response.data,
+      };
+    }
+
+    return {
+      success: false,
+      data: {
+        message: "비밀번호 재설정 이메일 전송 요청 중 오류가 발생했습니다.",
+      },
+    };
+  }
+};
+
+export default SendEmail;

--- a/src/lib/api/reset-password/send-email.ts
+++ b/src/lib/api/reset-password/send-email.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import axios from "axios";
 
 import instance from "@/lib/api/axios-instance";

--- a/src/lib/api/reset-password/send-email.ts
+++ b/src/lib/api/reset-password/send-email.ts
@@ -17,6 +17,12 @@ const SendEmail = async (email: string, redirectUrl: string) => {
     return { success: false, data: response.data };
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {
+      if (error.response.status === 400) {
+        return {
+          success: false,
+          data: { message: "존재하지 않는 유저입니다." },
+        };
+      }
       return {
         success: false,
         data: error.response.data,

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -18,8 +18,8 @@ export type UserSettingInput = {
 };
 
 export type ResetPasswordInput = {
-  password: string;
   passwordConfirmation: string;
+  password: string;
   token: string;
 };
 


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #106 <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

비밀번호 재설정을 구현했습니다!
로그인창에서 "비밀번호를 잊으셨나요?"를 클릭하면 이메일인풋이 있는 모달/드로어가 뜹니다.
이때 로그인을 안 한 상태여도 **가입된 이메일**을 입력하면 제대로 전송이 됩니다.
이메일을 들어가면 메일이 오는데 메일로 링크 접속을 하면 비밀번호 재설정 페이지로 갑니다.
비밀번호 재설정에 성공하면 로그인 페이지로 이동합니다.
성공과 오류 모두 토스트로 보여줍니다.

## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

![image](https://github.com/user-attachments/assets/1efe110f-e76e-43b9-b9cc-7576ddec444c)
로그인 안 한 상태에서 가입된 이메일을 입력하여 링크를 보냅니다. / 로그인한 상태여도 됩니다.

========================================================================

![image](https://github.com/user-attachments/assets/501a1f50-7b0f-40de-add7-b6af5447c422)
이렇게 메일이 옵니다.

========================================================================

![image](https://github.com/user-attachments/assets/6685668a-28c2-4262-ba00-b8deb29d271b)
링크 클릭하면 로그아웃 상태에서 비밀번호 재설정 페이지를 들어갈 수 있습니다.
이때 링크 주소가 `http://localhost:3000/reset-password?token=eyJhbGciOiJIUzI1NiIsInR5cCI6Ik~~~~` 이런식으로 오는데
이 토큰으로 로그인을 대체하는것 같습니다. 비밀번호 재설정을 하고 난뒤 로그인 페이지로 이동하고, 바뀐 비밀번호를 통해 로그인이 가능합니다.

## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->

일단은 http://localhost:3000로 넣었고 추후 실제 배포 주소로 바꾸겠습니다.