### PR TITLE
✨ Feat(#109): 팀 초대/참여 API 기능 구현

### DIFF
--- a/src/app/(board)/board/[boardId]/_components/board-detail/copy-team-token.tsx
+++ b/src/app/(board)/board/[boardId]/_components/board-detail/copy-team-token.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import clsx from "clsx";
 import { useRouter } from "next/navigation";
 
 import { useToast } from "@/hooks";
+import isTokenExpire from "@/utils/get-token-expire";
 
 const CopyTeamToken = ({ token }: { token: string }) => {
   const toast = useToast();
   const router = useRouter();
+
+  const isExpire = isTokenExpire(token);
 
   const copyToClipboard = () => {
     navigator.clipboard
@@ -24,17 +28,31 @@ const CopyTeamToken = ({ token }: { token: string }) => {
     <div className="relative">
       <div className="mt-40 w-full truncate rounded-2xl border border-brand-primary p-16 text-text-secondary">
         <span
-          className="cursor-pointer hover:text-brand-primary hover:underline"
-          onClick={copyToClipboard}
+          className={clsx(
+            {
+              "line-through text-text-default cursor-not-allowed": isExpire,
+            },
+            {
+              "cursor-pointer hover:text-brand-primary hover:underline":
+                !isExpire,
+            },
+          )}
+          onClick={!isExpire ? copyToClipboard : undefined}
         >
           {token}
         </span>
       </div>
       <span className="absolute -top-10 left-25 flex items-center gap-6 bg-background-primary px-6 text-text-primary">
         팀 참여 토큰
-        <span className="text-12-400 text-text-disabled">
-          (토큰을 복사하여 팀에 참여하세요)
-        </span>
+        {isExpire ? (
+          <span className="text-12-400 text-brand-primary">
+            (만료된 토큰입니다)
+          </span>
+        ) : (
+          <span className="text-12-400 text-brand-primary">
+            (토큰을 복사하여 팀에 참여하세요)
+          </span>
+        )}
       </span>
     </div>
   );

--- a/src/app/(board)/board/[boardId]/_components/board-detail/copy-team-token.tsx
+++ b/src/app/(board)/board/[boardId]/_components/board-detail/copy-team-token.tsx
@@ -2,6 +2,7 @@
 
 import clsx from "clsx";
 import { useRouter } from "next/navigation";
+import { useMemo } from "react";
 
 import { useToast } from "@/hooks";
 import isTokenExpire from "@/utils/get-token-expire";
@@ -10,7 +11,7 @@ const CopyTeamToken = ({ token }: { token: string }) => {
   const toast = useToast();
   const router = useRouter();
 
-  const isExpire = isTokenExpire(token);
+  const isExpire = useMemo(() => isTokenExpire(token), [token]);
 
   const copyToClipboard = () => {
     navigator.clipboard

--- a/src/app/(board-management)/_components/token-input.tsx
+++ b/src/app/(board-management)/_components/token-input.tsx
@@ -15,7 +15,7 @@ const TokenInput = () => {
   return (
     <FieldWrapper
       label={
-        <span>
+        <div className="flex items-center">
           <abbr
             className="text-brand-tertiary no-underline"
             title="필수입력"
@@ -23,8 +23,12 @@ const TokenInput = () => {
           >
             *
           </abbr>
-          &nbsp;팀 참여 토큰
-        </span>
+          &nbsp;팀 참여 토큰&nbsp;
+          <span className="text-14-400 text-text-default">
+            (토큰 만료기한은 <span className="text-brand-primary">3일</span>
+            입니다.)
+          </span>
+        </div>
       }
       id="token"
       errorMessage={errors.content?.token?.message || ""}

--- a/src/app/(team-management)/join-team/_components/join-team-form.tsx
+++ b/src/app/(team-management)/join-team/_components/join-team-form.tsx
@@ -1,28 +1,55 @@
-/* eslint-disable no-console */
-
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useAtom } from "jotai";
 import { SubmitHandler, useForm } from "react-hook-form";
 
-import { Button, FieldWrapper, Input } from "@/components/common";
+import { Button, FieldWrapper, FloatButton, Input } from "@/components/common";
+import { useToast } from "@/hooks";
+import acceptInvitation from "@/lib/api/group/accept-invitation";
 import { teamJoinSchema } from "@/lib/schemas/team-manage";
-import { TeamJoinInput } from "@/types/team-management";
+import { LoadingSpinner } from "@/public/assets/icons";
+import userAtom from "@/stores/user-atom";
+import { InvitationRequestType, TeamJoinInput } from "@/types/team-management";
 
 const JoinTeamForm = () => {
+  const [user] = useAtom(userAtom);
+  const toast = useToast();
+  const queryClient = useQueryClient();
+
   const {
     register,
     handleSubmit,
+    reset,
     formState: { errors, isValid },
   } = useForm<TeamJoinInput>({
     resolver: zodResolver(teamJoinSchema),
     mode: "onBlur",
-    reValidateMode: "onChange",
+    reValidateMode: "onBlur",
+  });
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: (data: InvitationRequestType) => acceptInvitation(data),
   });
 
   const handleSubmitJoinForm: SubmitHandler<TeamJoinInput> = (data) => {
-    // TODO: API 연동 - 현재 사용자 email 담아서 초대수락 post 요청
-    console.log(data);
+    const submitData: InvitationRequestType = {
+      token: data.token,
+      userEmail: user.email,
+    };
+
+    mutate(submitData, {
+      onSuccess: () => {
+        // TODO: 응답에 팀 id 오게 해달라고 다른 팀이 요청했다고 함. 그럼 해당 페이지로 이동
+        toast.success("해당 팀에 참여되었습니다.");
+        queryClient.invalidateQueries({ queryKey: ["userData"] });
+      },
+      onError: (error) => {
+        toast.error(error.message);
+        reset();
+      },
+    });
   };
 
   return (
@@ -31,25 +58,38 @@ const JoinTeamForm = () => {
       onSubmit={handleSubmit(handleSubmitJoinForm)}
     >
       <FieldWrapper
-        label="팀 링크"
+        label="팀 참여 토큰"
         id="token"
         errorMessage={errors.token?.message || ""}
       >
         <Input
-          {...register("token")}
+          {...register("token", {
+            required: true,
+          })}
           id="token"
-          placeholder="팀 링크를 입력해주세요."
+          placeholder="팀 참여 토큰을 입력해주세요."
           isError={!!errors.token}
         />
       </FieldWrapper>
-      <Button
-        disabled={!isValid}
-        type="submit"
-        variant="primary"
-        className="mt-16 h-47 w-full"
-      >
-        참여하기
-      </Button>
+      {isPending ? (
+        <FloatButton
+          variant="primary"
+          disabled
+          className="mt-16 h-47 w-full"
+          Icon={<LoadingSpinner width={30} height={30} />}
+        >
+          참여중
+        </FloatButton>
+      ) : (
+        <Button
+          disabled={!isValid}
+          type="submit"
+          variant="primary"
+          className="mt-16 h-47 w-full"
+        >
+          참여하기
+        </Button>
+      )}
     </form>
   );
 };

--- a/src/app/(team-management)/join-team/page.tsx
+++ b/src/app/(team-management)/join-team/page.tsx
@@ -5,8 +5,12 @@ import JoinTeamForm from "./_components/join-team-form";
 const JoinTeamPage = () => (
   <>
     <h1 className="text-24-500 md:text-32 lg:text-40">팀 참여하기</h1>
-    <p className="mb-24 mt-12 text-14-400 text-text-disabled md:my-36 md:mt-24 md:text-16-400">
-      공유받은 팀 링크를 입력해 참여할 수 있어요.
+    <p className="mt-12 text-14-400 text-text-disabled md:mt-24 md:text-16-400">
+      공유받은 팀 참여 토큰을 입력해 참여할 수 있어요.
+    </p>
+    <p className="mb-24 mt-8 text-14-400 text-text-default md:mb-36">
+      (생성한지 <span className="text-brand-primary">3일 </span>
+      지난 토큰은 참여할 수 없어요)
     </p>
     <JoinTeamForm />
     <p>

--- a/src/app/[teamId]/_components/member/add-member-modal.tsx
+++ b/src/app/[teamId]/_components/member/add-member-modal.tsx
@@ -1,18 +1,49 @@
 "use client";
 
-import { Button, Drawer, Modal } from "@/components/common";
+import { useMutation } from "@tanstack/react-query";
+import { usePathname } from "next/navigation";
+import { useMemo } from "react";
+
+import { Button, Drawer, FloatButton, Modal } from "@/components/common";
 import { useIsMobile, useToast, useToggle } from "@/hooks";
-import { IconPlusCurrent } from "@/public/assets/icons";
+import createInvitationToken from "@/lib/api/group/create-invitation-token";
+import { IconPlusCurrent, LoadingSpinner } from "@/public/assets/icons";
 
 const AddMemberModal = () => {
+  const pathname = usePathname();
+
+  const boardId = useMemo(() => pathname.split("/")[1], [pathname]);
+
   const { value: isOpen, handleOn, handleOff } = useToggle();
   const toast = useToast();
   const isMobile = useIsMobile();
 
+  const copyToClipboard = (token: string) => {
+    navigator.clipboard
+      .writeText(token)
+      .then(() => {
+        toast.success("링크가 생성되어 복사되었습니다.");
+      })
+      .catch(() => {
+        toast.error("링크가 복사되지 않았습니다.");
+      });
+  };
+
+  const { mutate, isPending } = useMutation({
+    mutationFn: () => createInvitationToken(Number(boardId)),
+    onSuccess: (res) => {
+      copyToClipboard(res);
+    },
+    onError: (error) => {
+      toast.error(error.message);
+    },
+    // onSettled: () => {
+    //   handleOff();
+    // },
+  });
+
   const handleClickCopy = () => {
-    // TODO: 링크 생성해서 복사하기
-    toast.success("링크가 복사되었습니다.");
-    handleOff();
+    mutate();
   };
 
   const ModalComponent = isMobile ? Drawer : Modal;
@@ -32,15 +63,26 @@ const AddMemberModal = () => {
           showCloseButton
           onClose={handleOff}
           title="멤버 초대"
-          description="그룹에 참여할 수 있는 링크를 복사합니다."
+          description="그룹에 참여할 수 있는 토큰을 복사합니다."
         >
-          <Button
-            onClick={handleClickCopy}
-            variant="primary"
-            className="mt-16 h-47 w-full"
-          >
-            복사하기
-          </Button>
+          {isPending ? (
+            <FloatButton
+              variant="primary"
+              disabled
+              className="mt-16 h-47 w-full"
+              Icon={<LoadingSpinner width={30} height={30} />}
+            >
+              복사 중
+            </FloatButton>
+          ) : (
+            <Button
+              onClick={handleClickCopy}
+              variant="primary"
+              className="mt-16 h-47 w-full"
+            >
+              복사하기
+            </Button>
+          )}
         </ModalComponent>
       )}
     </>

--- a/src/app/[teamId]/_components/member/add-member-modal.tsx
+++ b/src/app/[teamId]/_components/member/add-member-modal.tsx
@@ -9,12 +9,20 @@ import { useIsMobile, useToast, useToggle } from "@/hooks";
 import createInvitationToken from "@/lib/api/group/create-invitation-token";
 import { IconPlusCurrent, LoadingSpinner } from "@/public/assets/icons";
 
+import RedirectBoardModal from "./redirect-board-modal";
+
 const AddMemberModal = () => {
   const pathname = usePathname();
 
   const boardId = useMemo(() => pathname.split("/")[1], [pathname]);
 
   const { value: isOpen, handleOn, handleOff } = useToggle();
+  const {
+    value: isOpenBoard,
+    handleOn: boardHandleOn,
+    handleOff: boardHandleOff,
+  } = useToggle();
+
   const toast = useToast();
   const isMobile = useIsMobile();
 
@@ -33,13 +41,14 @@ const AddMemberModal = () => {
     mutationFn: () => createInvitationToken(Number(boardId)),
     onSuccess: (res) => {
       copyToClipboard(res);
+      boardHandleOn();
     },
     onError: (error) => {
       toast.error(error.message);
     },
-    // onSettled: () => {
-    //   handleOff();
-    // },
+    onSettled: () => {
+      handleOff();
+    },
   });
 
   const handleClickCopy = () => {
@@ -84,6 +93,9 @@ const AddMemberModal = () => {
             </Button>
           )}
         </ModalComponent>
+      )}
+      {isOpenBoard && (
+        <RedirectBoardModal isMobile={isMobile} handleOff={boardHandleOff} />
       )}
     </>
   );

--- a/src/app/[teamId]/_components/member/redirect-board-modal.tsx
+++ b/src/app/[teamId]/_components/member/redirect-board-modal.tsx
@@ -20,7 +20,15 @@ const RedirectBoardModal = ({
       showCloseButton
       onClose={handleOff}
       title="모집글 작성"
-      description="복사된 토큰으로 모집글을 작성하시겠습니까?"
+      description={
+        <div className="flex flex-col gap-4">
+          <span>복사된 토큰으로 모집글을 작성하시겠습니까?</span>
+          <span className="text-14-400 text-text-default">
+            (토큰 만료기한은 <span className="text-brand-primary">3일</span>{" "}
+            입니다.)
+          </span>
+        </div>
+      }
     >
       <div className="flex gap-8">
         <Button variant="secondary" onClick={handleOff} className="h-48 w-136">

--- a/src/app/[teamId]/_components/member/redirect-board-modal.tsx
+++ b/src/app/[teamId]/_components/member/redirect-board-modal.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link";
+
+import { Button, Drawer, Modal } from "@/components/common";
+
+interface RedirectBoardModalProps {
+  isMobile: boolean;
+  handleOff: () => void;
+}
+
+const RedirectBoardModal = ({
+  isMobile,
+  handleOff,
+}: RedirectBoardModalProps) => {
+  const ModalComponent = isMobile ? Drawer : Modal;
+
+  return (
+    <ModalComponent
+      showCloseButton
+      onClose={handleOff}
+      title="모집글 작성"
+      description="복사된 토큰으로 모집글을 작성하시겠습니까?"
+    >
+      <div className="flex gap-8">
+        <Button variant="secondary" onClick={handleOff} className="h-48 w-136">
+          아니오
+        </Button>
+        <Link href="/create-board">
+          <Button variant="primary" className="h-48 w-136">
+            작성하기
+          </Button>
+        </Link>
+      </div>
+    </ModalComponent>
+  );
+};
+
+export default RedirectBoardModal;

--- a/src/app/[teamId]/_components/member/redirect-board-modal.tsx
+++ b/src/app/[teamId]/_components/member/redirect-board-modal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 
 import { Button, Drawer, Modal } from "@/components/common";

--- a/src/lib/api/group/accept-invitation.ts
+++ b/src/lib/api/group/accept-invitation.ts
@@ -15,6 +15,9 @@ const acceptInvitation = async (data: InvitationRequestType) => {
     return res.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
+      if (error.response?.data.message === "Validation Failed") {
+        throw new Error("로그인 후 팀 참여가 가능합니다.");
+      }
       throw error.response?.data;
     } else {
       throw new Error(OTHER_TYPE_ERROR);

--- a/src/lib/api/group/accept-invitation.ts
+++ b/src/lib/api/group/accept-invitation.ts
@@ -1,13 +1,9 @@
 import axios, { AxiosResponse } from "axios";
 
 import { OTHER_TYPE_ERROR } from "@/constants/error-message";
+import { InvitationRequestType } from "@/types/team-management";
 
 import instance from "../axios-instance";
-
-type InvitationRequestType = {
-  userEmail: string;
-  token: string;
-};
 
 // 초대 수락 생성 POST 요청
 const acceptInvitation = async (data: InvitationRequestType) => {

--- a/src/lib/api/group/accept-invitation.ts
+++ b/src/lib/api/group/accept-invitation.ts
@@ -1,0 +1,29 @@
+import axios, { AxiosResponse } from "axios";
+
+import { OTHER_TYPE_ERROR } from "@/constants/error-message";
+
+import instance from "../axios-instance";
+
+type InvitationRequestType = {
+  userEmail: string;
+  token: string;
+};
+
+// 초대 수락 생성 POST 요청
+const acceptInvitation = async (data: InvitationRequestType) => {
+  try {
+    const res: AxiosResponse<string> = await instance.post(
+      `/groups/accept-invitation`,
+      data,
+    );
+    return res.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw error.response?.data;
+    } else {
+      throw new Error(OTHER_TYPE_ERROR);
+    }
+  }
+};
+
+export default acceptInvitation;

--- a/src/lib/api/group/create-invitation-token.ts
+++ b/src/lib/api/group/create-invitation-token.ts
@@ -13,6 +13,9 @@ const createInvitationToken = async (groupId: number) => {
     return res.data;
   } catch (error) {
     if (axios.isAxiosError(error)) {
+      if (error.response?.data.message === "Validation Failed") {
+        throw new Error("로그인 후 팀 참여가 가능합니다.");
+      }
       throw error.response?.data;
     } else {
       throw new Error(OTHER_TYPE_ERROR);

--- a/src/lib/api/group/create-invitation-token.ts
+++ b/src/lib/api/group/create-invitation-token.ts
@@ -1,0 +1,23 @@
+import axios, { AxiosResponse } from "axios";
+
+import { OTHER_TYPE_ERROR } from "@/constants/error-message";
+
+import instance from "../axios-instance";
+
+// 초대 토큰 생성 GET 요청
+const createInvitationToken = async (groupId: number) => {
+  try {
+    const res: AxiosResponse<string> = await instance.get(
+      `/groups/${groupId}/invitation`,
+    );
+    return res.data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      throw error.response?.data;
+    } else {
+      throw new Error(OTHER_TYPE_ERROR);
+    }
+  }
+};
+
+export default createInvitationToken;

--- a/src/types/modal-drawer/index.ts
+++ b/src/types/modal-drawer/index.ts
@@ -14,7 +14,7 @@ export interface CommonProps {
   /**
    * `오버레이의 설명 텍스트를 설정합니다.`
    */
-  description?: string;
+  description?: ReactNode;
 
   /**
    * `오버레이 닫기 버튼의 표시 여부를 설정합니다.`

--- a/src/types/team-management/index.ts
+++ b/src/types/team-management/index.ts
@@ -6,7 +6,6 @@ export type TeamAddEditInput = {
 
 // 팀 참여 input
 export type TeamJoinInput = {
-  email: string;
   token: string;
 };
 
@@ -17,4 +16,10 @@ export type CreateEditTeamResponse = {
   updatedAt: string;
   createdAt: string;
   id: number;
+};
+
+// 팀 참여 request
+export type InvitationRequestType = {
+  userEmail: string;
+  token: string;
 };

--- a/src/utils/get-token-expire.ts
+++ b/src/utils/get-token-expire.ts
@@ -1,0 +1,19 @@
+const isTokenExpire = (token: string) => {
+  const base64Url = token.split(".")[1];
+  const base64 = base64Url.replace(/-/g, "+").replace(/_/g, "/");
+  const jsonPayload = decodeURIComponent(
+    atob(base64)
+      .split("")
+      .map((c) => `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`)
+      .join(""),
+  );
+
+  const parseToken = JSON.parse(jsonPayload);
+
+  const currentDate = new Date();
+  const tokenExpirationDate = new Date(parseToken.exp * 1000);
+
+  return currentDate > tokenExpirationDate;
+};
+
+export default isTokenExpire;


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #109  <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

### 멤버 초대 토큰 발급

토큰이 발급되고 바로 게시물을 쓸 수 있게 구현했어요. 

https://github.com/user-attachments/assets/8efa1a20-0eeb-4ad1-b70b-e816fab239be

### 팀 참여 기능

다른팀이 해당 팀 참여하면 response 로 팀 아이디 달라고 요청해서 그거 수정되면 참여하고 바로 해당 팀 이동하게 수정할 예정입니다.


https://github.com/user-attachments/assets/06be49a6-4286-40ff-8c6d-52cfb72a5980

그리고 상단네비바에서 팀목록 드롭다운에서 그룹정보 가져오는거 쿼리초기화 해서 팀 참여되면 바로 드롭다운 팀 목록에 생기도록했습니다

<img width="194" alt="image" src="https://github.com/user-attachments/assets/6c24cb71-74ac-40e9-9eab-bb44167adddb">


### 토큰 만료

만료된 토큰은 만료되었다고 표시했어요

<img width="620" alt="image" src="https://github.com/user-attachments/assets/ec511964-26a3-4ba1-be41-3e9f48888b7f">



## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [ ] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
