### PR TITLE
🚑️ Fix(#196): 계정설정페이지 이미지만 변경X 수정 

### DIFF
--- a/src/app/(auth)/_components/reset-password/reset-password-component.tsx
+++ b/src/app/(auth)/_components/reset-password/reset-password-component.tsx
@@ -46,8 +46,7 @@ const ResetPasswordComponent = ({
   const onSubmit: SubmitHandler<EmailInput> = async ({ email }) => {
     setIsLoading(true);
 
-    // NOTE - 배포 주소로 변경 예정
-    const redirectUrl = "http://localhost:3000";
+    const redirectUrl = "https://3team-coworkers.netlify.app";
 
     const { success: apiSuccess, data } = await SendEmail(email, redirectUrl);
 

--- a/src/app/(auth)/_components/user-setting/image-input.tsx
+++ b/src/app/(auth)/_components/user-setting/image-input.tsx
@@ -4,7 +4,7 @@
 
 import { useMutation } from "@tanstack/react-query";
 import Image from "next/image";
-import { ChangeEvent, memo, useState } from "react";
+import { ChangeEvent, memo, useEffect, useState } from "react";
 import { useFormContext } from "react-hook-form";
 
 import { FieldWrapper } from "@/components/common";
@@ -27,6 +27,11 @@ const ImageInput = memo(() => {
   const { mutate, isPending } = useMutation({
     mutationFn: (image: File) => imageUpload(image),
   });
+
+  /* eslint-disable react-hooks/exhaustive-deps */
+  useEffect(() => {
+    setImgUrl(watch("image"));
+  }, [watch("image")]);
 
   const handleImage = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];

--- a/src/app/(auth)/_components/user-setting/name-input.tsx
+++ b/src/app/(auth)/_components/user-setting/name-input.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect } from "react";
 import { useFormContext } from "react-hook-form";
 
 import { Button, FieldWrapper, Input } from "@/components/common";
@@ -9,8 +10,14 @@ const NameInput = () => {
   const {
     register,
     watch,
+    setValue,
     formState: { errors },
   } = useFormContext<UserSettingInput>();
+
+  useEffect(() => {
+    const nicknameValue = watch("nickname");
+    setValue("nickname", nicknameValue);
+  }, [watch, setValue]);
 
   return (
     <FieldWrapper

--- a/src/app/(auth)/_components/user-setting/user-setting-form.tsx
+++ b/src/app/(auth)/_components/user-setting/user-setting-form.tsx
@@ -41,7 +41,7 @@ const UserSettingForm = () => {
   const { setValue } = methods;
 
   const mutation = useMutation({
-    mutationFn: (data: { nickname: string; image: string | null }) =>
+    mutationFn: (data: { nickname?: string; image: string | null }) =>
       EditUser(data),
     onSuccess: (data, variables) => {
       if (data.success) {
@@ -52,7 +52,7 @@ const UserSettingForm = () => {
 
         setUser((prevUser) => ({
           ...prevUser,
-          nickname: variables.nickname,
+          nickname: variables.nickname || prevUser.nickname,
           image: variables.image || prevUser.image,
         }));
         router.replace(`/user-setting`);
@@ -67,7 +67,15 @@ const UserSettingForm = () => {
 
   const handleSubmitUser: SubmitHandler<UserSettingInput> = (data) => {
     const { image, nickname } = data;
-    mutation.mutate({ image, nickname });
+    const updatedData: { nickname?: string; image: string | null } = {
+      image,
+    };
+
+    if (nickname !== user.nickname) {
+      updatedData.nickname = nickname;
+    }
+
+    mutation.mutate(updatedData);
   };
 
   const handleChangePasswordClick = () => {

--- a/src/app/(auth)/_components/user-setting/user-setting-form.tsx
+++ b/src/app/(auth)/_components/user-setting/user-setting-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useMutation } from "@tanstack/react-query";
 import { useAtomValue, useSetAtom } from "jotai";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
 import { useToast } from "@/hooks";
@@ -39,6 +39,11 @@ const UserSettingForm = () => {
   });
 
   const { setValue } = methods;
+
+  useEffect(() => {
+    setValue("image", user.image || "");
+    setValue("nickname", user.nickname || "");
+  }, [user.image, user.nickname, setValue]);
 
   const mutation = useMutation({
     mutationFn: (data: { nickname?: string; image: string | null }) =>

--- a/src/types/auth/index.ts
+++ b/src/types/auth/index.ts
@@ -12,7 +12,7 @@ export type SignUpInput = {
 
 export type UserSettingInput = {
   image: string | null;
-  nickname: string;
+  nickname?: string;
 };
 
 export type ResetPasswordInput = {


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #196 <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

계정설정페이지에서 이미지만 변경할수있도록 수정했습니다.
추가로 계정설정페이지에서 새로고침하거나 이미지, 닉네임 변경했을때 placeholder? 기본값이 사라지는 오류 수정했습니다.

++ 이메일로 비밀번호 재설정할때 리다이렉트 주소가 로컬호소트로 되있어서 이번 pr에 같이 수정해서 올립니다!!


## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->


https://github.com/user-attachments/assets/d1b29933-2202-4be8-8a12-a9b3d786c4ee


## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
