### PR TITLE
🔨 Refactor(#209): 드롭다운 리팩토링

### DIFF
--- a/src/components/nav-bar/nav-sidebar.tsx
+++ b/src/components/nav-bar/nav-sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import clsx from "clsx";
 import { motion } from "framer-motion";
 import { useAtom } from "jotai";
 import Link from "next/link";
@@ -80,23 +81,32 @@ const NavSideBar = ({ isOpen, onClose }: SidebarProps) => {
         className="absolute right-22 top-22"
       />
       <div className="ml-16 mt-75">
-        {hasTeams ? (
-          <ul className="space-y-24">
-            {teams.map((membership) => (
-              <li key={membership.group.id}>
-                <Link
-                  href={`/team/${membership.group.id}`}
-                  onClick={() =>
-                    handleLinkClick(membership.group.name, membership.group.id)
-                  }
-                >
-                  {membership.group.name}
-                </Link>
-              </li>
-            ))}
-          </ul>
-        ) : (
-          isLoggedIn && (
+        {isLoggedIn ? (
+          <>
+            {hasTeams && (
+              <ul
+                className={clsx("space-y-24", {
+                  "max-h-[calc(100vh-190px)] overflow-y-auto":
+                    teams.length > 10,
+                })}
+              >
+                {teams.map((membership) => (
+                  <li key={membership.group.id}>
+                    <Link
+                      href={`/team/${membership.group.id}`}
+                      onClick={() =>
+                        handleLinkClick(
+                          membership.group.name,
+                          membership.group.id,
+                        )
+                      }
+                    >
+                      {membership.group.name}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
             <div className="mt-24 flex flex-col gap-24">
               <Link
                 href="/create-team"
@@ -105,14 +115,26 @@ const NavSideBar = ({ isOpen, onClose }: SidebarProps) => {
               >
                 팀 생성하기
               </Link>
+              <Link
+                href="/boards"
+                onClick={onClose}
+                className="text-brand-primary"
+              >
+                모집게시판
+              </Link>
             </div>
-          )
+          </>
+        ) : (
+          <div className="mt-24 flex flex-col gap-24">
+            <Link
+              href="/boards"
+              onClick={onClose}
+              className="text-brand-primary"
+            >
+              모집게시판
+            </Link>
+          </div>
         )}
-        <div className="mt-24 flex flex-col gap-24">
-          <Link href="/boards" onClick={onClose} className="text-brand-primary">
-            모집게시판
-          </Link>
-        </div>
       </div>
     </motion.div>
   );

--- a/src/components/nav-bar/nav-sidebar.tsx
+++ b/src/components/nav-bar/nav-sidebar.tsx
@@ -101,7 +101,9 @@ const NavSideBar = ({ isOpen, onClose }: SidebarProps) => {
                         )
                       }
                     >
-                      {membership.group.name}
+                      <span className="block w-full truncate">
+                        {membership.group.name}
+                      </span>
                     </Link>
                   </li>
                 ))}

--- a/src/components/nav-bar/team-dropdown.tsx
+++ b/src/components/nav-bar/team-dropdown.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import clsx from "clsx";
 import { setCookie } from "cookies-next";
 import { useAtom } from "jotai";
 import Image from "next/image";
@@ -80,7 +81,12 @@ const TeamDropdown = () => {
   return (
     <div className="mt-1 cursor-pointer whitespace-nowrap text-16-500 text-text-primary">
       <DropDown handleClose={teamDropdown.handleOff}>
-        <DropDown.Trigger onClick={teamDropdown.handleToggle}>
+        <DropDown.Trigger
+          onClick={() => {
+            teamDropdown.handleToggle();
+            setIsExpanded(false);
+          }}
+        >
           <div className="hidden items-center md:flex">
             {recentTeam?.teamName ? dropdownTeamName : "팀선택"}
             <IconDropdown className="ml-8" />
@@ -89,7 +95,7 @@ const TeamDropdown = () => {
         <DropDown.Menu
           isOpen={teamDropdown.value}
           position="top-50 right-0"
-          className="w-140"
+          className={clsx("w-140", { "max-h-330 overflow-y-auto": isExpanded })}
         >
           {visibleTeams.map((membership) => (
             <Link
@@ -130,7 +136,7 @@ const TeamDropdown = () => {
           ))}
           {userData?.memberships.length > 4 && (
             <DropDown.Item onClick={toggleExpand}>
-              <div className="flex items-center justify-center">
+              <div className="flex items-center justify-center pb-7 pt-8">
                 {isExpanded ? "접기" : "팀 더보기"}
               </div>
             </DropDown.Item>
@@ -138,7 +144,7 @@ const TeamDropdown = () => {
           <div className="rounded-12 border-t-2 border-border-primary" />
           <Link href="/create-team">
             <DropDown.Item onClick={teamDropdown.handleOff}>
-              <div className="flex items-center justify-center">
+              <div className="flex items-center justify-center pb-7 pt-8">
                 <IconPlusCurrent className="mr-5 stroke-white" />팀 생성하기
               </div>
             </DropDown.Item>

--- a/src/components/nav-bar/team-dropdown.tsx
+++ b/src/components/nav-bar/team-dropdown.tsx
@@ -46,7 +46,11 @@ const TeamDropdown = () => {
         setCookie("firstTeamName", firstTeam.name);
       }
       if (recentTeam) {
-        setDropdownTeamName(recentTeam.teamName);
+        setDropdownTeamName(
+          recentTeam.teamName.length > 6
+            ? `${recentTeam.teamName.slice(0, 4)}...`
+            : recentTeam.teamName,
+        );
       } else {
         setDropdownTeamName(userData.memberships[0].group.name);
         setRecentTeam({
@@ -129,7 +133,11 @@ const TeamDropdown = () => {
                       />
                     )}
                   </div>
-                  <span className="ml-12">{membership.group.name}</span>
+                  <span className="ml-12">
+                    {membership.group.name.length > 6
+                      ? `${membership.group.name.slice(0, 4)}...`
+                      : membership.group.name}
+                  </span>
                 </div>
               </DropDown.Item>
             </Link>

--- a/src/components/nav-bar/user-dropdown.tsx
+++ b/src/components/nav-bar/user-dropdown.tsx
@@ -59,7 +59,9 @@ const UserDropdown = () => {
           position="top-50 right-0 lg:left-0"
         >
           <Link href="/user/history">
-            <DropDown.Item>마이 히스토리</DropDown.Item>
+            <DropDown.Item onClick={userDropdown.handleToggle}>
+              마이 히스토리
+            </DropDown.Item>
           </Link>
           <Link href="/user-setting">
             <DropDown.Item onClick={userDropdown.handleToggle}>


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #209 <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

일반 헤더의 팀/유저 드롭다운 + 모바일일때 사이드바 리팩토링 진행했습니다.
1. 팀 드롭다운에서 팀목록이 길어지면 스크롤 생기게 만들었습니다. + (모바일일때 사이드바도)
2. 팀 드롭다운 클릭할때마다 팀 더보기 전 상태로 초기화했습니다.
3. 로그인한 상태일때 모바일 사이드바(팀 드롭다운 역할)에 팀 생성하기와 모집게시판이 보이도록 수정했어요.
4. 팀 드롭다운 패딩값을 수정했습니다.
5. 마이히스토리 클릭시 이동과 함께 드롭다운이 닫히게했습니다.
6. 긴 팀이름은 앞에 4글자만 보여주도록 수정했습니다. / 모바일사이드바는 팀이미지가 없어서 ...으로 줄이게했습니다.

## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->


https://github.com/user-attachments/assets/d167995f-c60a-4703-9dc9-a0ae7fdd0f04


![image](https://github.com/user-attachments/assets/5ea73e54-4906-4905-af16-8a6d4c499fe8)
ㄴ> 팀이름 길이 수정전입니다!!

![image](https://github.com/user-attachments/assets/7f754e8b-6517-4f2e-8566-1043e6e7f498) 
![image](https://github.com/user-attachments/assets/8ca1c9aa-50b6-4ac0-b5b5-16366e3a689a)


## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->

브랜치 하나에서 리팩토링을 다하려다가 정신차리고 나눠서 올려요..!!
그래서 브랜치 이름이 이상합니다,,, 죄송합니다 😭
