### PR TITLE
🔨 Refactor(#230): 로그인/ 계정설정 리팩토링 

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,7 @@ const nextConfig = {
     domains: [
       "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
       "k.kakaocdn.net",
+      "t1.kakaocdn.net",
       "lh3.googleusercontent.com",
     ],
   },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,11 +2,23 @@
 const nextConfig = {
   reactStrictMode: true,
   images: {
-    domains: [
-      "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
-      "k.kakaocdn.net",
-      "t1.kakaocdn.net",
-      "lh3.googleusercontent.com",
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "sprint-fe-project.s3.ap-northeast-2.amazonaws.com",
+      },
+      {
+        protocol: "http",
+        hostname: "k.kakaocdn.net",
+      },
+      {
+        protocol: "http",
+        hostname: "t1.kakaocdn.net",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+      },
     ],
   },
   webpack: (config) => {

--- a/src/app/(auth)/_components/login/signin-form.tsx
+++ b/src/app/(auth)/_components/login/signin-form.tsx
@@ -91,13 +91,13 @@ const SignInForm: React.FC = () => {
   const handleKakaoLogin = () => {
     const state = randomString(10);
     const KAKAO_LOGIN_URL = `${KAKAO_AUTHORIZE_URL}?response_type=code&client_id=${process.env.NEXT_PUBLIC_KAKAO_REST_API_KEY}&redirect_uri=${process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI}&scope=profile_nickname,profile_image&state=${state}`;
-    window.location.href = KAKAO_LOGIN_URL;
+    window.location.replace(KAKAO_LOGIN_URL);
   };
 
   const handleGoogleLogin = () => {
     const state = randomString(10);
     const GOOGLE_LOGIN_URL = `${GOOGLE_AUTHORIZE_URL}?client_id=${process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID}&redirect_uri=${process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI}&response_type=code&scope=profile email&state=${state}`;
-    window.location.href = GOOGLE_LOGIN_URL;
+    window.location.replace(GOOGLE_LOGIN_URL);
   };
 
   return (

--- a/src/app/(auth)/_components/user-setting/index.ts
+++ b/src/app/(auth)/_components/user-setting/index.ts
@@ -1,0 +1,6 @@
+export { default as CancelUserComponent } from "./cancel-user-component";
+export { default as ChangePasswordComponent } from "./change-password-component";
+export { default as EmailInput } from "./email-input";
+export { default as ImageInput } from "./image-input";
+export { default as NameInput } from "./name-input";
+export { default as PasswordInput } from "./password-input";

--- a/src/app/(auth)/_components/user-setting/name-input.tsx
+++ b/src/app/(auth)/_components/user-setting/name-input.tsx
@@ -36,9 +36,9 @@ const NameInput = () => {
         <Button
           type="submit"
           variant="primary"
-          className="absolute right-16 top-9 z-[5] h-32 w-50"
+          className="absolute right-16 top-9 z-[5] h-32 w-130"
         >
-          변경
+          이미지 / 이름 변경
         </Button>
       </div>
     </FieldWrapper>

--- a/src/app/(auth)/_components/user-setting/user-setting-form.tsx
+++ b/src/app/(auth)/_components/user-setting/user-setting-form.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
+import PageLoading from "@/components/loading";
 import { useToast } from "@/hooks";
 import EditUser from "@/lib/api/user-setting/edit-user";
 import { userSettingSchema } from "@/lib/schemas/auth";
@@ -23,6 +24,7 @@ import PasswordInput from "./password-input";
 const UserSettingForm = () => {
   const [isChangeOpen, setIsChangeOpen] = useState(false);
   const [isCancelOpen, setIsCancelOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const router = useRouter();
   const setUser = useSetAtom(userAtom);
   const user = useAtomValue(userAtom);
@@ -41,9 +43,12 @@ const UserSettingForm = () => {
   const { setValue } = methods;
 
   useEffect(() => {
-    setValue("image", user.image || "");
-    setValue("nickname", user.nickname || "");
-  }, [user.image, user.nickname, setValue]);
+    if (user) {
+      setValue("image", user.image || "");
+      setValue("nickname", user.nickname || "");
+      setIsLoading(false);
+    }
+  }, [user, setValue]);
 
   const mutation = useMutation({
     mutationFn: (data: { nickname?: string; image: string | null }) =>
@@ -90,6 +95,10 @@ const UserSettingForm = () => {
   const handleCancelUserClick = () => {
     setIsCancelOpen(true);
   };
+
+  if (isLoading) {
+    return <PageLoading message="Loading" />;
+  }
 
   return (
     <>

--- a/src/app/(auth)/user-setting/page.tsx
+++ b/src/app/(auth)/user-setting/page.tsx
@@ -1,4 +1,4 @@
-import UserSettingForm from "../_components/user-setting/user-setting-form";
+import UserSettingForm from "./user-setting-form";
 
 const UserSetting = () => (
   <div className="flex w-full flex-col items-center justify-center">

--- a/src/app/(auth)/user-setting/user-setting-form.tsx
+++ b/src/app/(auth)/user-setting/user-setting-form.tsx
@@ -7,19 +7,20 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FormProvider, SubmitHandler, useForm } from "react-hook-form";
 
+import {
+  CancelUserComponent,
+  ChangePasswordComponent,
+  EmailInput,
+  ImageInput,
+  NameInput,
+  PasswordInput,
+} from "@/app/(auth)/_components/user-setting";
 import PageLoading from "@/components/loading";
 import { useToast } from "@/hooks";
 import EditUser from "@/lib/api/user-setting/edit-user";
 import { userSettingSchema } from "@/lib/schemas/auth";
 import { userAtom } from "@/stores";
 import { UserSettingInput } from "@/types/auth";
-
-import CancelUserComponent from "./cancel-user-component";
-import ChangePasswordComponent from "./change-password-component";
-import EmailInput from "./email-input";
-import ImageInput from "./image-input";
-import NameInput from "./name-input";
-import PasswordInput from "./password-input";
 
 const UserSettingForm = () => {
   const [isChangeOpen, setIsChangeOpen] = useState(false);

--- a/src/app/(team-management)/_components/create-team-form.tsx
+++ b/src/app/(team-management)/_components/create-team-form.tsx
@@ -50,7 +50,7 @@ const CreateTeamForm = () => {
           teamName: res.name,
           groupId: res.id,
         });
-        window.location.href = `/team/${res.id}`;
+        window.location.replace(`/team/${res.id}`);
         queryClient.invalidateQueries({ queryKey: ["userData"] });
       },
       onError: (error) => {

--- a/src/app/my-teams/page.tsx
+++ b/src/app/my-teams/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
+import { useAtom, useSetAtom } from "jotai";
 import Lottie from "lottie-react";
 import Image from "next/image";
 import Link from "next/link";
@@ -10,13 +11,26 @@ import Motion from "@/components/common/framer-motion/motion";
 import getUserGroups from "@/lib/api/user/get-user-groups";
 import { ImgPlanet } from "@/public/assets/images";
 import TeamEmpty from "@/public/assets/lotties/team-empty.json";
-import { Group } from "@/types/user";
+import { recentTeamAtom, userAtom } from "@/stores";
 
 const MyTeams = () => {
   const { data: userGroups } = useQuery({
     queryKey: ["userGroups"],
     queryFn: () => getUserGroups(),
   });
+
+  const [user] = useAtom(userAtom);
+  const userId = user.id;
+
+  const setRecentTeam = useSetAtom(recentTeamAtom(userId));
+
+  const handleTeamClick = (team: { name: string; id: number }) => {
+    setRecentTeam({
+      teamName: team.name,
+      groupId: team.id,
+    });
+    window.location.replace(`/team/${team.id}`);
+  };
 
   return (
     <div>
@@ -44,9 +58,10 @@ const MyTeams = () => {
               transition={{ duration: 1.5 }}
               className="w-full"
             >
-              <Link
+              <button
+                type="button"
                 className="mb-12 flex w-full flex-col items-center justify-center gap-15 rounded-12 bg-background-secondary px-14 py-30 hover:bg-background-tertiary"
-                href={`/team/${team.id}`}
+                onClick={() => handleTeamClick(team)}
               >
                 <div className="relative size-52">
                   {team.image ? (
@@ -68,7 +83,7 @@ const MyTeams = () => {
                   )}
                 </div>
                 <span className="text-16-500">{team.name}</span>
-              </Link>
+              </button>
             </Motion>
           ))}
         </section>

--- a/src/app/team/[teamId]/_components/member/delete-member-modal.tsx
+++ b/src/app/team/[teamId]/_components/member/delete-member-modal.tsx
@@ -53,10 +53,10 @@ const DeleteMemberModal = ({
     onSuccess: () => {
       if (isSameMember) {
         if (replaceId === "team-empty") {
-          router.push(`/team-empty`);
+          window.location.href = "/team-empty";
           queryClient.invalidateQueries({ queryKey: ["userData"] });
         } else {
-          router.push(`/team/${replaceId}`);
+          window.location.href = `/team/${replaceId}`;
           queryClient.invalidateQueries({ queryKey: ["userData"] });
         }
       } else {

--- a/src/app/team/[teamId]/_components/team-card/delete-team-modal.tsx
+++ b/src/app/team/[teamId]/_components/team-card/delete-team-modal.tsx
@@ -31,7 +31,6 @@ const TeamDeleteModal = ({
   const [groupIdList] = useAtom(groupIdListAtom);
   const [isLoading, setIsLoading] = useState(false);
   const [value, setValue] = useState("");
-  const router = useRouter();
   const toast = useToast();
   const isMobile = useIsMobile();
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);

--- a/src/components/nav-bar/team-dropdown.tsx
+++ b/src/components/nav-bar/team-dropdown.tsx
@@ -2,7 +2,7 @@
 
 import { useQuery } from "@tanstack/react-query";
 import clsx from "clsx";
-import { setCookie } from "cookies-next";
+import { getCookie, setCookie } from "cookies-next";
 import { useAtom } from "jotai";
 import Image from "next/image";
 import Link from "next/link";
@@ -25,13 +25,14 @@ const fetchUserData = async (): Promise<User> => {
 const TeamDropdown = () => {
   const [user] = useAtom(userAtom);
   const userId = user.id;
+  const userCookieId = getCookie("userId");
   const useRecentTeamAtom = useMemo(() => recentTeamAtom(userId), [userId]);
   const [recentTeam, setRecentTeam] = useAtom(useRecentTeamAtom);
 
   const { data: userData, isLoading } = useQuery<User>({
     queryKey: ["userData"],
     queryFn: fetchUserData,
-    enabled: !!userId,
+    enabled: !!userCookieId,
     staleTime: 60000,
     gcTime: 300000,
   });
@@ -70,7 +71,7 @@ const TeamDropdown = () => {
     setIsExpanded(!isExpanded);
   };
 
-  if (isLoading || !userId) {
+  if (isLoading || !userCookieId) {
     return null;
   }
 

--- a/src/components/nav-bar/user-dropdown.tsx
+++ b/src/components/nav-bar/user-dropdown.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getCookie } from "cookies-next";
 import { useAtom } from "jotai";
 import Image from "next/image";
 import Link from "next/link";
@@ -16,6 +17,7 @@ const UserDropdown = () => {
   const [user] = useAtom(userAtom);
   const [isLogoutOpen, setIsLogoutOpen] = useState(false);
   const userDropdown = useToggle();
+  const userCookieId = getCookie("userId");
 
   const openLogout = () => {
     setIsLogoutOpen(true);
@@ -26,7 +28,7 @@ const UserDropdown = () => {
     setIsLogoutOpen(false);
   };
 
-  if (user.id === 0) {
+  if (!userCookieId) {
     return (
       <Link href="/login" className="text-text-primary">
         로그인

--- a/src/components/nav-bar/user-dropdown.tsx
+++ b/src/components/nav-bar/user-dropdown.tsx
@@ -45,7 +45,7 @@ const UserDropdown = () => {
                 alt={user.nickname}
                 width={32}
                 height={32}
-                objectFit="cover"
+                style={{ width: "32px", height: "32px", objectFit: "cover" }}
                 className="mr-12 rounded-md"
               />
             ) : (

--- a/src/constants/auth-url.ts
+++ b/src/constants/auth-url.ts
@@ -1,5 +1,3 @@
-const GOOGLE_AUTHORIZE_URL = "https://accounts.google.com/o/oauth2/v2/auth";
-
-const KAKAO_AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";
-
-export { GOOGLE_AUTHORIZE_URL, KAKAO_AUTHORIZE_URL };
+export const GOOGLE_AUTHORIZE_URL =
+  "https://accounts.google.com/o/oauth2/v2/auth";
+export const KAKAO_AUTHORIZE_URL = "https://kauth.kakao.com/oauth/authorize";

--- a/src/constants/frequency.ts
+++ b/src/constants/frequency.ts
@@ -1,5 +1,3 @@
-import { FrequencyType } from "@/types/task-list";
-
 export const FREQUENCY_OPTIONS = [
   { value: "ONCE", label: "한 번" },
   { value: "DAILY", label: "매일 반복" },

--- a/src/lib/api/auth/sign-in.ts
+++ b/src/lib/api/auth/sign-in.ts
@@ -15,9 +15,11 @@ const signIn = async (email: string, password: string) => {
     const { data } = response;
 
     if (response.status === 200) {
-      cookies().set("token", data.accessToken);
-      cookies().set("refreshToken", data.refreshToken);
-      cookies().set("userId", data.user.id);
+      const maxAge = 60 * 60 * 24;
+
+      cookies().set("token", data.accessToken, { maxAge });
+      cookies().set("refreshToken", data.refreshToken, { maxAge });
+      cookies().set("userId", data.user.id, { maxAge });
 
       return { success: true, data };
     }

--- a/src/lib/api/auth/sign-up.ts
+++ b/src/lib/api/auth/sign-up.ts
@@ -23,9 +23,11 @@ const signUp = async (
     const { data } = response;
 
     if (response.status === 201) {
-      cookies().set("token", data.accessToken);
-      cookies().set("refreshToken", data.refreshToken);
-      cookies().set("userNickname", data.user.nickname);
+      const maxAge = 60 * 60 * 24;
+
+      cookies().set("token", data.accessToken, { maxAge });
+      cookies().set("refreshToken", data.refreshToken, { maxAge });
+      cookies().set("userNickname", data.user.nickname, { maxAge });
 
       return {
         success: true,

--- a/src/lib/api/oauth/google-auth.ts
+++ b/src/lib/api/oauth/google-auth.ts
@@ -53,9 +53,11 @@ const GoogleAuth = () => {
 
         if (response.status === 200) {
           success("로그인 성공");
-          setCookie("token", data.accessToken);
-          setCookie("refreshToken", data.refreshToken);
-          setCookie("userId", data.user.id);
+          setCookie("token", data.accessToken, { maxAge: 60 * 60 * 24 });
+          setCookie("refreshToken", data.refreshToken, {
+            maxAge: 60 * 60 * 24,
+          });
+          setCookie("userId", data.user.id, { maxAge: 60 * 60 * 24 });
 
           setUser({
             id: data.user.id,

--- a/src/lib/api/oauth/google-auth.ts
+++ b/src/lib/api/oauth/google-auth.ts
@@ -8,7 +8,6 @@ import { useEffect, useRef } from "react";
 import { useToast } from "@/hooks";
 import instance from "@/lib/api/axios-instance";
 import { userAtom } from "@/stores";
-import redirectTo from "@/utils/next-redirect";
 
 const GoogleAuth = () => {
   const { success, error } = useToast();
@@ -71,7 +70,7 @@ const GoogleAuth = () => {
             loginType: "GOOGLE",
           });
 
-          redirectTo("/");
+          window.location.replace("/");
         } else {
           error("로그인 요청 중 오류가 발생했습니다.");
         }

--- a/src/lib/api/oauth/kakao-auth.ts
+++ b/src/lib/api/oauth/kakao-auth.ts
@@ -40,9 +40,11 @@ const KakaoAuth = () => {
 
         if (response.status === 200) {
           success("로그인 성공");
-          setCookie("token", data.accessToken);
-          setCookie("refreshToken", data.refreshToken);
-          setCookie("userId", data.user.id);
+          setCookie("token", data.accessToken, { maxAge: 60 * 60 * 24 });
+          setCookie("refreshToken", data.refreshToken, {
+            maxAge: 60 * 60 * 24,
+          });
+          setCookie("userId", data.user.id, { maxAge: 60 * 60 * 24 });
 
           setUser({
             id: data.user.id,

--- a/src/lib/api/oauth/kakao-auth.ts
+++ b/src/lib/api/oauth/kakao-auth.ts
@@ -8,7 +8,6 @@ import { useEffect, useRef } from "react";
 import { useToast } from "@/hooks";
 import instance from "@/lib/api/axios-instance";
 import { userAtom } from "@/stores";
-import redirectTo from "@/utils/next-redirect";
 
 const KakaoAuth = () => {
   const { success, error } = useToast();
@@ -58,7 +57,7 @@ const KakaoAuth = () => {
             loginType: "KAKAO",
           });
 
-          redirectTo("/");
+          window.location.replace("/");
         } else {
           error("로그인 요청 중 오류가 발생했습니다.");
         }


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #230 <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

1. 카카오 로그인시 이미지에러 있다고 해서 도메인 추가했습니다.
2. 도메인 추가하면서 remotePatterns 권장한다길래 같이 바꿨어요
3. 구글 카카오 로그인하고 뒤로가기 누르면 에러뜨던데 window.location.replace로 뒤로가기 못하게 했습니다.
4. 계정설정에서 이미지 이름 "변경" 버튼이 헷갈린다는 의견이 있어서 "이미지 / 이름 변경" 으로 바꿨습니다.
5. 계정설정에서도 페이지로딩 추가해봤습니다.
6. 유저 드롭다운에서 유저 이미지를 팀 이미지 처럼 32x32 네모로 통일했습니다.
++++++
7. 로그인 여부 기존 아톰 방식에서 쿠키로 바꿨습니다.
8. empty-team에서 팀 이동했을때 헤더 드롭다운에 반영되도록 했습니다.
9. 로그인/회원가입시 토큰 유효기간을 24시간으로 바꿨습니다.
10. ustils의 validation 안쓰길래 지웠습니다.
11. 이런저런 리팩토링 했어요

## 📸 결과물

<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

![image](https://github.com/user-attachments/assets/2a19e8bd-3729-4634-ad67-bd85e058cdbd)
유저 드롭다운 정사각형 모양으로 바꿧습니다

![image](https://github.com/user-attachments/assets/f8020688-da25-462c-b5e2-3a33bb7f7401)
여기 버튼이 원래 변경이였는데 이미지 / 이름 변경으로 바꿨습니다.

나머지는 코드로 확인해주세요

## ✅ 체크 리스트

- [x] 적절한 Title 작성
- [x] 적절한 Label 지정
- [x] Assignee 및 Reviewer 지정
- [x] 로컬 작동 확인
- [x] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->

직접 이것저것 해보면서 오류 더 찾아보겠습니다.
