### PR TITLE
🔨 Refactor(#260): useIsMobile 최적화

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { Inter } from "next/font/google";
 import AppProvider from "@/components/app-provider";
 import ToastContainer from "@/components/common/toast/container";
 import StarsCanvas from "@/components/landing/star-canvas";
+import MobileSizeWatcher from "@/components/mobile-size-watcher";
 import MouseTrailer from "@/components/mouse-trailer";
 import NavBar from "@/components/nav-bar";
 import GoogleAnalytics from "@/lib/google-analytics";
@@ -53,6 +54,7 @@ const RootLayout: React.FC<Readonly<{ children: React.ReactNode }>> = ({
     >
       <StarsCanvas />
       <MouseTrailer />
+      <MobileSizeWatcher />
       {process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS ? (
         <GoogleAnalytics gaId={process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS} />
       ) : null}

--- a/src/components/mobile-size-watcher/index.ts
+++ b/src/components/mobile-size-watcher/index.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { useEffect } from "react";
+
+import { isMobileAtom } from "@/stores";
+
+/**
+ * 현재 화면 크기가 모바일인지 주시하는 컴포넌트입니다.
+ *
+ * 최상단 레이아웃에 박았습니다.
+ *
+ * @author ☯️채종민
+ */
+
+export default function MobileSizeWatcher() {
+  const [, setIsMobile] = useAtom(isMobileAtom);
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 480px)");
+
+    const handleMediaQueryChange = (e: MediaQueryListEvent) => {
+      setIsMobile(e.matches);
+    };
+
+    // 초기 렌더링 시 확인
+    setIsMobile(mediaQuery.matches);
+
+    // 미디어 쿼리 변경 시 이벤트 등록
+    mediaQuery.addEventListener("change", handleMediaQueryChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleMediaQueryChange);
+    };
+  }, [setIsMobile]);
+
+  return null;
+}

--- a/src/hooks/use-is-mobile.ts
+++ b/src/hooks/use-is-mobile.ts
@@ -1,23 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useAtom } from "jotai";
+
+import { isMobileAtom } from "@/stores";
 
 const useIsMobile = (): boolean => {
-  const [isMobile, setIsMobile] = useState(false);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setIsMobile(window.innerWidth <= 480);
-    };
-
-    handleResize();
-
-    window.addEventListener("resize", handleResize);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
+  const [isMobile] = useAtom(isMobileAtom);
 
   return isMobile;
 };

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,4 +1,5 @@
 export { default as groupIdListAtom } from "./group-list";
+export { default as isMobileAtom } from "./is-mobile-atom";
 export { default as pwLengthAtom } from "./pw-length-atom";
 export { default as recentTeamAtom } from "./recent-team-atom";
 export { RemoveToastAtom, ToastAtom } from "./toast";

--- a/src/stores/is-mobile-atom.ts
+++ b/src/stores/is-mobile-atom.ts
@@ -1,0 +1,6 @@
+import { atom } from "jotai";
+
+/** 모바일 화면인지 아닌지 */
+const isMobileAtom = atom<boolean>(false);
+
+export default isMobileAtom;


### PR DESCRIPTION
<!-- PR 제목은 "✨ Feat(#100): 이런저런 내용" 형식으로 작성 -->

## #️⃣ 이슈

- close #260 <!-- 이슈 번호 입력 -->

## 📝 작업 내용

<!-- 작업한 내용에 대해 작성해주세요. -->

useIsMobile 최적화 했어여.

제가 생각한 문제1:
resize는 화면 크기가 바뀔 떄 마다 코드가 돌아간다.

제가 생각한 문제2: 
useIsMobile를 여러 곳에서 사용한 경우 발생.
동일한 로직의 이벤트 리스너가 여러 번 등록된다.

문제1 + 문제2:
useIsMobile 여러 군데서 사용하고 있는 상황.
동일한 이벤트 핸들러 여러 개가  화면 크기가 바뀔 때 마다 돌아간다.

--- 

해결1:
resize 대신 matchMedia 사용.
그 특정 포인트에만 함수가 한번 돌아갑니다.

해결2:
화면 크기가 모바일인지에 대한 값을 저장한 전역변수 만듬(zotai) 사용.
화면 크기를 검사하는 컴포넌트 하나를 만들어서 루트 레이아웃에 박음.
나머지 컴포넌트는 전역변수 값을 이용만함.


---

결과
모바일인지 아닌지 정보를 가진 변수를 전역 변수 하나로만 관리 됨.
이벤트 리스너가 하나만 등록됨.
화면 크기 조정 시 코드가 덜 돈다.


## 📸 결과물

before(console 찍었을 경우)
![모바일](https://github.com/user-attachments/assets/88e05450-1cc6-4c3f-ba5b-43f9253e6a3d)

after
![미디어쿼리 활용](https://github.com/user-attachments/assets/4752487d-6c7d-414f-8d4e-da5acb77c644)


<!-- 결과물에 대한 스크린샷을 작성해주세요. -->

## ✅ 체크 리스트

- [ ] 적절한 Title 작성
- [ ] 적절한 Label 지정
- [ ] Assignee 및 Reviewer 지정
- [ ] 로컬 작동 확인
- [ ] Merge 되는 브랜치 확인

## 👩‍💻 공유 포인트 및 논의 사항

<!-- 공유하거나 논의할 사항을 작성해주세요. -->
